### PR TITLE
macros: Use EIGEN_STATIC_ASSERT_SAME_X_SIZE

### DIFF
--- a/include/pinocchio/bindings/python/spatial/explog.hpp
+++ b/include/pinocchio/bindings/python/spatial/explog.hpp
@@ -87,7 +87,10 @@ namespace pinocchio
       Matrix<typename Vector6Like::Scalar, 7, 1, PINOCCHIO_EIGEN_PLAIN_TYPE(Vector6Like)::Options>
       exp6_proxy_quatvec(const Vector6Like & vec6)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector6Like, 6);
+      typedef typename Vector6Like::Scalar Scalar;
+      typedef Eigen::Matrix<Scalar, 6, 1, PINOCCHIO_EIGEN_PLAIN_TYPE(Vector6Like)::Options> Vector6;
+
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector6Like, Vector6);
       return quaternion::exp6(vec6); // use quaternion-exp6 overload
     }
 
@@ -162,7 +165,10 @@ namespace pinocchio
       Matrix<typename Vector4Like::Scalar, 3, 1, PINOCCHIO_EIGEN_PLAIN_TYPE(Vector4Like)::Options>
       log3_proxy_quatvec(const Vector4Like & v)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector4Like, 4);
+      typedef typename Vector4Like::Scalar Scalar;
+      typedef Eigen::Matrix<Scalar, 4, 1, PINOCCHIO_EIGEN_PLAIN_TYPE(Vector4Like)::Options> Vector4;
+
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector4Like, Vector4);
       typedef typename Vector4Like::Scalar Scalar;
       typedef Eigen::Quaternion<Scalar, PINOCCHIO_EIGEN_PLAIN_TYPE(Vector4Like)::Options>
         Quaternion_t;
@@ -178,8 +184,11 @@ namespace pinocchio
       Matrix<typename Vector4Like::Scalar, 3, 1, PINOCCHIO_EIGEN_PLAIN_TYPE(Vector4Like)::Options>
       log3_proxy_quatvec(const Vector4Like & v, Eigen::Ref<Matrix1Like> theta)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector4Like, 4);
       typedef typename Vector4Like::Scalar Scalar;
+      typedef Eigen::Matrix<Scalar, 4, 1, PINOCCHIO_EIGEN_PLAIN_TYPE(Vector4Like)::Options> Vector4;
+
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector4Like, Vector4);
+
       typedef Eigen::Quaternion<Scalar, PINOCCHIO_EIGEN_PLAIN_TYPE(Vector4Like)::Options>
         Quaternion_t;
       typedef Eigen::Map<const Quaternion_t> ConstQuaternionMap_t;
@@ -195,8 +204,10 @@ namespace pinocchio
       Matrix<typename Vector4Like::Scalar, 3, 1, PINOCCHIO_EIGEN_PLAIN_TYPE(Vector4Like)::Options>
       log3_proxy_quatvec_fix(const Vector4Like & v, _Scalar & theta)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector4Like, 4);
       typedef typename Vector4Like::Scalar Scalar;
+      typedef Eigen::Matrix<Scalar, 4, 1, PINOCCHIO_EIGEN_PLAIN_TYPE(Vector4Like)::Options> Vector4;
+
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector4Like, Vector4);
       typedef Eigen::Quaternion<Scalar, PINOCCHIO_EIGEN_PLAIN_TYPE(Vector4Like)::Options>
         Quaternion_t;
       typedef Eigen::Map<const Quaternion_t> ConstQuaternionMap_t;
@@ -218,8 +229,10 @@ namespace pinocchio
     MotionTpl<typename Vector7Like::Scalar, PINOCCHIO_EIGEN_PLAIN_TYPE(Vector7Like)::Options>
     log6_proxy_quatvec(const Vector7Like & q)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector7Like, 7);
       typedef typename Vector7Like::Scalar Scalar;
+      typedef Eigen::Matrix<Scalar, 7, 1, PINOCCHIO_EIGEN_PLAIN_TYPE(Vector7Like)::Options> Vector7;
+
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector7Like, Vector7);
       static constexpr int Options = PINOCCHIO_EIGEN_PLAIN_TYPE(Vector7Like)::Options;
       typedef Eigen::Quaternion<Scalar, Options> Quaternion;
       typedef Eigen::Map<const Quaternion, Options> ConstQuaternionMap;

--- a/include/pinocchio/src/algorithm/centroidal-derivatives.hxx
+++ b/include/pinocchio/src/algorithm/centroidal-derivatives.hxx
@@ -209,9 +209,9 @@ namespace pinocchio
       const Eigen::MatrixBase<Vector3Like> & v3,
       const Eigen::MatrixBase<Matrix6xLikeOut> & Fout)
     {
-      EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix6xLikeIn, 6, Eigen::Dynamic)
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3Like, 3)
-      EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix6xLikeOut, 6, Eigen::Dynamic)
+      EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix6xLikeIn, context::Matrix6xs)
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3Like, context::Vector3)
+      EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix6xLikeOut, context::Matrix6xs)
 
       PINOCCHIO_CHECK_ARGUMENT_SIZE(
         Fin.cols(), Fout.cols(), "Fin and Fout do not have the same number of columns");
@@ -231,8 +231,8 @@ namespace pinocchio
     void translateForceSet(
       const Eigen::MatrixBase<Matrix6xLike> & F, const Eigen::MatrixBase<Vector3Like> & v3)
     {
-      EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix6xLike, 6, Eigen::Dynamic)
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3Like, 3)
+      EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix6xLike, context::Matrix6xs)
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3Like, context::Vector3)
 
       for (Eigen::Index k = 0; k < F.cols(); ++k)
       {

--- a/include/pinocchio/src/constraints/sets/second-order-cone-jordan-operation.hxx
+++ b/include/pinocchio/src/constraints/sets/second-order-cone-jordan-operation.hxx
@@ -64,7 +64,7 @@ namespace pinocchio
     template<typename Vector3In>
     static bool IsInSymmetricCone(const Eigen::MatrixBase<Vector3In> & x)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In, Vector3s);
       if (x[2] - x.template head<2>().norm() >= -Eigen::NumTraits<Scalar>::dummy_precision())
       {
         return true;
@@ -76,7 +76,7 @@ namespace pinocchio
     template<typename Vector3In>
     static bool IsInSymmetricConeInterior(const Eigen::MatrixBase<Vector3In> & x)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In, Vector3s);
       if (x[2] - x.template head<2>().norm() > -Eigen::NumTraits<Scalar>::dummy_precision())
       {
         return true;
@@ -88,7 +88,7 @@ namespace pinocchio
     template<typename Vector3In>
     static void MakeConeIdentityElement(const Eigen::MatrixBase<Vector3In> & x)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In, Vector3s);
 
       Vector3In & x_ = x.const_cast_derived();
       x_ << Scalar(0), Scalar(0), Scalar(1);
@@ -106,7 +106,7 @@ namespace pinocchio
     template<typename Vector3In>
     static void MakeConeRandomElement(const Eigen::MatrixBase<Vector3In> & x)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In, Vector3s);
 
       Vector3In & x_ = x.const_cast_derived();
       x_.setRandom();
@@ -169,8 +169,8 @@ namespace pinocchio
     static Scalar JordanDotProduct(
       const Eigen::MatrixBase<Vector3In1> & x, const Eigen::MatrixBase<Vector3In2> & y)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In1, 3);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In2, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In1, Vector3s);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In2, Vector3s);
 
       const Scalar xn = x.coeff(2);
       const Scalar yn = y.coeff(2);
@@ -185,7 +185,7 @@ namespace pinocchio
     template<typename Vector3In>
     static Scalar JordanNorm2(const Eigen::MatrixBase<Vector3In> & x)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In, Vector3s);
       assert(IsInSymmetricCone(x) && "x is not in the SOC.");
 
       const Scalar xn = x.coeff(2);
@@ -217,8 +217,8 @@ namespace pinocchio
     static Vector3s
     JordanProduct(const Eigen::MatrixBase<Vector3In1> & x, const Eigen::MatrixBase<Vector3In2> & y)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In1, 3);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In2, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In1, Vector3s);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In2, Vector3s);
 
       Vector3s res;
       res.template head<2>() = y[2] * x.template head<2>() + x[2] * y.template head<2>();
@@ -239,9 +239,9 @@ namespace pinocchio
       const Eigen::MatrixBase<Vector3In2> & y,
       const Eigen::MatrixBase<Vector3Out> & res)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In1, 3);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In2, 3);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3Out, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In1, Vector3s);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In2, Vector3s);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3Out, Vector3s);
 
       res.const_cast_derived() = JordanProduct(x, y);
     }
@@ -257,8 +257,8 @@ namespace pinocchio
     static Vector3s JordanInverseProduct(
       const Eigen::MatrixBase<Vector3In1> & x, const Eigen::MatrixBase<Vector3In2> & y)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In1, 3);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In2, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In1, Vector3s);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In2, Vector3s);
       assert(IsInSymmetricConeInterior(x) && "x is not in the interior of the SOC.");
 
       // see ecos implementation paper
@@ -288,9 +288,9 @@ namespace pinocchio
       const Eigen::MatrixBase<Vector3In2> & y,
       const Eigen::MatrixBase<Vector3Out> & res)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In1, 3);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In2, 3);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3Out, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In1, Vector3s);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In2, Vector3s);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3Out, Vector3s);
       assert(IsInSymmetricConeInterior(x) && "x is not in the interior of the SOC.");
 
       res.const_cast_derived() = JordanInverseProduct(x, y);
@@ -306,8 +306,8 @@ namespace pinocchio
     static Vector3s ApplyQuadraticForm(
       const Eigen::MatrixBase<Vector3In1> & x, const Eigen::MatrixBase<Vector3In2> & y)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In1, 3);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In2, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In1, Vector3s);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In2, Vector3s);
       assert(IsInSymmetricConeInterior(x) && "x is not in the interior of the SOC.");
 
       const Scalar a = JordanNorm(x);
@@ -338,9 +338,9 @@ namespace pinocchio
       const Eigen::MatrixBase<Vector3In2> & y,
       const Eigen::MatrixBase<Vector3Out> & res)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In1, 3);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In2, 3);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3Out, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In1, Vector3s);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In2, Vector3s);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3Out, Vector3s);
       assert(IsInSymmetricConeInterior(x) && "x is not in the interior of the SOC.");
 
       res.const_cast_derived() = ApplyQuadraticForm(x, y);
@@ -356,8 +356,8 @@ namespace pinocchio
     static Vector3s ApplyInverseQuadraticForm(
       const Eigen::MatrixBase<Vector3In1> & x, const Eigen::MatrixBase<Vector3In2> & y)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In1, 3);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In2, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In1, Vector3s);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In2, Vector3s);
       assert(IsInSymmetricConeInterior(x) && "x is not in the interior of the SOC.");
 
       const Scalar a = JordanNorm(x);
@@ -388,9 +388,9 @@ namespace pinocchio
       const Eigen::MatrixBase<Vector3In2> & y,
       const Eigen::MatrixBase<Vector3Out> & res)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In1, 3);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In2, 3);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3Out, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In1, Vector3s);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In2, Vector3s);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3Out, Vector3s);
       assert(IsInSymmetricConeInterior(x) && "x is not in the interior of the SOC.");
 
       res.const_cast_derived() = ApplyInverseQuadraticForm(x, y);
@@ -415,9 +415,9 @@ namespace pinocchio
       const Eigen::MatrixBase<Vector3In2> & x,
       const Eigen::MatrixBase<Vector3Out> & v)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In1, 3);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In2, 3);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3Out, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In1, Vector3s);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In2, Vector3s);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3Out, Vector3s);
       assert(IsInSymmetricConeInterior(lambda) && "lambda is not in the interior of the SOC.");
 
       Vector3Out & v_ = v.const_cast_derived();
@@ -462,10 +462,10 @@ namespace pinocchio
       const Eigen::MatrixBase<Vector3Out> & lambda,
       const Eigen::MatrixBase<Vector4Out> & w)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In1, 3);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In2, 3);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3Out, 3);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector4Out, 4);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In1, Vector3s);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In2, Vector3s);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3Out, Vector3s);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector4Out, Vector4s);
       assert(IsInSymmetricConeInterior(x) && "x is not in the interior of the SOC.");
       assert(IsInSymmetricConeInterior(y) && "y is not in the interior of the SOC.");
 
@@ -504,8 +504,8 @@ namespace pinocchio
     static Vector3s
     ApplyScaling(const Eigen::MatrixBase<Vector4In> & w, const Eigen::MatrixBase<Vector3In> & x)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector4In, 4);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector4In, Vector4s);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In, Vector3s);
 
       const auto v = w.template head<3>();
       const Scalar beta = w[3];
@@ -526,9 +526,9 @@ namespace pinocchio
       const Eigen::MatrixBase<Vector3In> & x,
       const Eigen::MatrixBase<Vector3Out> & res)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector4In, 4);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In, 3);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3Out, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector4In, Vector4s);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In, Vector3s);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3Out, Vector3s);
 
       res.const_cast_derived() = ApplyScaling(w, x);
     }
@@ -542,8 +542,8 @@ namespace pinocchio
     static Vector3s ApplyInverseScaling(
       const Eigen::MatrixBase<Vector4In> & w, const Eigen::MatrixBase<Vector3In> & x)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector4In, 4);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector4In, Vector4s);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In, Vector3s);
 
       const auto v = w.template head<3>();
       const Scalar beta = w[3];
@@ -563,9 +563,9 @@ namespace pinocchio
       const Eigen::MatrixBase<Vector3In> & x,
       const Eigen::MatrixBase<Vector3Out> & res)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector4In, 4);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3In, 3);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3Out, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector4In, Vector4s);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3In, Vector3s);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3Out, Vector3s);
 
       res.const_cast_derived() = ApplyInverseScaling(w, x);
     }
@@ -578,9 +578,8 @@ namespace pinocchio
     static void RetrieveScalingMatrix(
       const Eigen::MatrixBase<Vector4In> & w, const Eigen::MatrixBase<Matrix3Out> & W)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector4In, 4);
-      EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix3Out, 3, 3);
-
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector4In, Vector4s);
+      EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix3Out, Matrix3s)
       const auto v = w.template head<3>();
       const Scalar beta = w[3];
 
@@ -599,8 +598,8 @@ namespace pinocchio
     static void RetrieveSquaredScalingMatrix(
       const Eigen::MatrixBase<Vector4In> & w, const Eigen::MatrixBase<Matrix3Out> & W2)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector4In, 4);
-      EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix3Out, 3, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector4In, Vector4s);
+      EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix3Out, Matrix3s);
 
       const auto v = w.template head<3>();
       const Scalar beta = w[3];
@@ -625,8 +624,8 @@ namespace pinocchio
     static void RetrieveInverseScalingMatrix(
       const Eigen::MatrixBase<Vector4In> & w, const Eigen::MatrixBase<Matrix3Out> & Winv)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector4In, 4);
-      EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix3Out, 3, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector4In, Vector4s);
+      EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix3Out, Matrix3s);
 
       const auto v = w.template head<3>();
       const Scalar beta = w[3];

--- a/include/pinocchio/src/math/rotation.hxx
+++ b/include/pinocchio/src/math/rotation.hxx
@@ -27,8 +27,8 @@ namespace pinocchio
     const Scalar & sin_value,
     const Eigen::MatrixBase<Matrix3> & res)
   {
-    EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3, 3);
-    EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix3, 3, 3);
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3, context::Vector3);
+    EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix3, context::Matrix3x);
 
     assert(isUnitary(axis) && "The axis is not unitary.");
 
@@ -77,7 +77,7 @@ namespace pinocchio
   template<typename Matrix3>
   void normalizeRotation(const Eigen::MatrixBase<Matrix3> & rot)
   {
-    EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix3, 3, 3);
+    EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix3, context::Matrix3x);
     Matrix3 & rot_ = PINOCCHIO_EIGEN_CONST_CAST(Matrix3, rot);
 
     typedef typename Matrix3::Scalar Scalar;
@@ -99,7 +99,7 @@ namespace pinocchio
   typename PINOCCHIO_EIGEN_PLAIN_TYPE(Matrix3)
     orthogonalProjection(const Eigen::MatrixBase<Matrix3> & mat)
   {
-    EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix3, 3, 3);
+    EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix3, context::Matrix3x);
     typedef typename PINOCCHIO_EIGEN_PLAIN_TYPE(Matrix3) ReturnType;
 
     typedef Eigen::JacobiSVD<Matrix3> SVD;

--- a/include/pinocchio/src/multibody/joint/joint-ellipsoid.hxx
+++ b/include/pinocchio/src/multibody/joint/joint-ellipsoid.hxx
@@ -80,7 +80,7 @@ namespace pinocchio
     template<typename Vector3Like>
     JointMotion __mult__(const Eigen::MatrixBase<Vector3Like> & v) const
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3Like, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3Like, context::Vector3);
       // Compute first 6 rows from first 2 columns
       Eigen::Matrix<Scalar, 6, 1> result = S.template leftCols<2>() * v.template head<2>();
 
@@ -253,7 +253,7 @@ namespace pinocchio
   operator*(
     const Eigen::MatrixBase<Matrix6Like> & Y, const JointMotionSubspaceEllipsoidTpl<S2, O2> & S)
   {
-    EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix6Like, 6, 6);
+    EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix6Like, context::Matrix6xs);
     return Y * S.S;
   }
 

--- a/include/pinocchio/src/multibody/joint/joint-free-flyer.hxx
+++ b/include/pinocchio/src/multibody/joint/joint-free-flyer.hxx
@@ -47,7 +47,10 @@ namespace pinocchio
     template<typename Vector6Like>
     JointMotion __mult__(const Eigen::MatrixBase<Vector6Like> & vj) const
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector6Like, 6);
+      typedef typename Vector6Like::Scalar Scalar;
+      typedef Eigen::Matrix<Scalar, 6, 1, PINOCCHIO_EIGEN_PLAIN_TYPE(Vector6Like)::Options> Vector6;
+
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector6Like, Vector6);
       return JointMotion(vj);
     }
 
@@ -113,7 +116,9 @@ namespace pinocchio
     const JointMotionSubspaceIdentityTpl<Scalar, Options> &,
     const Eigen::MatrixBase<Vector6Like> & v)
   {
-    EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector6Like, 6);
+    typedef Eigen::Matrix<Scalar, 6, 1, PINOCCHIO_EIGEN_PLAIN_TYPE(Vector6Like)::Options> Vector6;
+
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector6Like, Vector6);
     //    typedef typename JointMotionSubspaceIdentityTpl<Scalar,Options>::Motion Motion;
     typedef MotionRef<const Vector6Like> Motion;
     return Motion(v.derived());

--- a/include/pinocchio/src/multibody/joint/joint-helical-unaligned.hxx
+++ b/include/pinocchio/src/multibody/joint/joint-helical-unaligned.hxx
@@ -286,7 +286,10 @@ namespace pinocchio
     template<typename Vector1Like>
     JointMotion __mult__(const Eigen::MatrixBase<Vector1Like> & v) const
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector1Like, 1);
+      typedef typename Vector1Like::Scalar Scalar;
+      typedef Eigen::Matrix<Scalar, 1, 1, PINOCCHIO_EIGEN_PLAIN_TYPE(Vector1Like)::Options> Vector1;
+
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector1Like, Vector1);
       assert(v.size() == 1);
       return JointMotion(m_axis, v[0], Scalar(v[0] * m_pitch));
     }
@@ -489,7 +492,7 @@ namespace pinocchio
       typedef Eigen::Matrix<Scalar, 6, 1> ReturnType;
       static inline ReturnType run(const Eigen::MatrixBase<M6Like> & Y, const Constraint & cru)
       {
-        EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(M6Like, 6, 6);
+        EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(M6Like, context::Matrix6xs);
         return Y.derived().template middleCols<3>(Constraint::ANGULAR) * cru.axis()
                + Y.derived().template middleCols<3>(Constraint::LINEAR) * cru.axis() * cru.h();
       }

--- a/include/pinocchio/src/multibody/joint/joint-helical-unaligned.hxx
+++ b/include/pinocchio/src/multibody/joint/joint-helical-unaligned.hxx
@@ -286,10 +286,7 @@ namespace pinocchio
     template<typename Vector1Like>
     JointMotion __mult__(const Eigen::MatrixBase<Vector1Like> & v) const
     {
-      typedef typename Vector1Like::Scalar Scalar;
-      typedef Eigen::Matrix<Scalar, 1, 1, PINOCCHIO_EIGEN_PLAIN_TYPE(Vector1Like)::Options> Vector1;
-
-      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector1Like, Vector1);
+      EIGEN_STATIC_ASSERT_SIZE_1x1(Vector1Like,);
       assert(v.size() == 1);
       return JointMotion(m_axis, v[0], Scalar(v[0] * m_pitch));
     }

--- a/include/pinocchio/src/multibody/joint/joint-helical-unaligned.hxx
+++ b/include/pinocchio/src/multibody/joint/joint-helical-unaligned.hxx
@@ -286,7 +286,7 @@ namespace pinocchio
     template<typename Vector1Like>
     JointMotion __mult__(const Eigen::MatrixBase<Vector1Like> & v) const
     {
-      EIGEN_STATIC_ASSERT_SIZE_1x1(Vector1Like,);
+      EIGEN_STATIC_ASSERT_SIZE_1x1(Vector1Like);
       assert(v.size() == 1);
       return JointMotion(m_axis, v[0], Scalar(v[0] * m_pitch));
     }

--- a/include/pinocchio/src/multibody/joint/joint-helical.hxx
+++ b/include/pinocchio/src/multibody/joint/joint-helical.hxx
@@ -457,7 +457,10 @@ namespace pinocchio
     template<typename Vector1Like>
     JointMotion __mult__(const Eigen::MatrixBase<Vector1Like> & v) const
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector1Like, 1);
+      typedef typename Vector1Like::Scalar Scalar;
+      typedef Eigen::Matrix<Scalar, 1, 1, PINOCCHIO_EIGEN_PLAIN_TYPE(Vector1Like)::Options> Vector1;
+
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector1Like, Vector1);
       assert(v.size() == 1);
       return JointMotion(v[0], v[0] * m_pitch);
     }
@@ -691,7 +694,7 @@ namespace pinocchio
       static inline ReturnType
       run(const Eigen::MatrixBase<M6Like> & Y, const Constraint & constraint)
       {
-        EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(M6Like, 6, 6);
+        EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(M6Like, context::Matrix6xs);
         return (Y.col(Inertia::ANGULAR + axis) + Y.col(Inertia::LINEAR + axis) * constraint.h());
       }
     };

--- a/include/pinocchio/src/multibody/joint/joint-helical.hxx
+++ b/include/pinocchio/src/multibody/joint/joint-helical.hxx
@@ -457,10 +457,7 @@ namespace pinocchio
     template<typename Vector1Like>
     JointMotion __mult__(const Eigen::MatrixBase<Vector1Like> & v) const
     {
-      typedef typename Vector1Like::Scalar Scalar;
-      typedef Eigen::Matrix<Scalar, 1, 1, PINOCCHIO_EIGEN_PLAIN_TYPE(Vector1Like)::Options> Vector1;
-
-      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector1Like, Vector1);
+      EIGEN_STATIC_ASSERT_SIZE_1x1(Vector1Like);
       assert(v.size() == 1);
       return JointMotion(v[0], v[0] * m_pitch);
     }

--- a/include/pinocchio/src/multibody/joint/joint-planar.hxx
+++ b/include/pinocchio/src/multibody/joint/joint-planar.hxx
@@ -74,7 +74,7 @@ namespace pinocchio
     MotionPlanarTpl(const Eigen::MatrixBase<Vector3Like> & vj)
     : m_data(vj)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3Like, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3Like, Vector3);
     }
 
     inline PlainReturnType plain() const
@@ -256,7 +256,7 @@ namespace pinocchio
     template<typename Vector3Like>
     JointMotion __mult__(const Eigen::MatrixBase<Vector3Like> & vj) const
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3Like, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3Like, context::Vector3);
       return JointMotion(vj);
     }
 
@@ -422,7 +422,7 @@ namespace pinocchio
   inline Eigen::Matrix<S2, 6, 3, O2>
   operator*(const Eigen::MatrixBase<M6Like> & Y, const JointMotionSubspacePlanarTpl<S2, O2> &)
   {
-    EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(M6Like, 6, 6);
+    EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(M6Like, context::Matrix6xs);
     typedef Eigen::Matrix<S2, 6, 3, O2> Matrix63;
 
     Matrix63 IS;

--- a/include/pinocchio/src/multibody/joint/joint-prismatic-unaligned.hxx
+++ b/include/pinocchio/src/multibody/joint/joint-prismatic-unaligned.hxx
@@ -68,7 +68,7 @@ namespace pinocchio
     : m_axis(axis)
     , m_v(v)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3Like, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3Like, Vector3);
     }
 
     inline PlainReturnType plain() const
@@ -270,13 +270,16 @@ namespace pinocchio
     JointMotionSubspacePrismaticUnalignedTpl(const Eigen::MatrixBase<Vector3Like> & axis)
     : m_axis(axis)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3Like, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3Like, Vector3);
     }
 
     template<typename Vector1Like>
     JointMotion __mult__(const Eigen::MatrixBase<Vector1Like> & v) const
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector1Like, 1);
+      typedef typename Vector1Like::Scalar Scalar;
+      typedef Eigen::Matrix<Scalar, 1, 1, PINOCCHIO_EIGEN_PLAIN_TYPE(Vector1Like)::Options> Vector1;
+
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector1Like, Vector1);
       return JointMotion(m_axis, v[0]);
     }
 
@@ -445,7 +448,7 @@ namespace pinocchio
         typename MultiplicationOp<Eigen::MatrixBase<M6Like>, Constraint>::ReturnType ReturnType;
       static inline ReturnType run(const Eigen::MatrixBase<M6Like> & Y, const Constraint & cru)
       {
-        EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(M6Like, 6, 6);
+        EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(M6Like, context::Matrix6xs);
         return Y.derived().template middleCols<3>(Constraint::LINEAR) * cru.axis();
       }
     };

--- a/include/pinocchio/src/multibody/joint/joint-prismatic-unaligned.hxx
+++ b/include/pinocchio/src/multibody/joint/joint-prismatic-unaligned.hxx
@@ -276,10 +276,7 @@ namespace pinocchio
     template<typename Vector1Like>
     JointMotion __mult__(const Eigen::MatrixBase<Vector1Like> & v) const
     {
-      typedef typename Vector1Like::Scalar Scalar;
-      typedef Eigen::Matrix<Scalar, 1, 1, PINOCCHIO_EIGEN_PLAIN_TYPE(Vector1Like)::Options> Vector1;
-
-      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector1Like, Vector1);
+      EIGEN_STATIC_ASSERT_SIZE_1x1(Vector1Like);
       return JointMotion(m_axis, v[0]);
     }
 

--- a/include/pinocchio/src/multibody/joint/joint-prismatic.hxx
+++ b/include/pinocchio/src/multibody/joint/joint-prismatic.hxx
@@ -343,10 +343,7 @@ namespace pinocchio
     template<typename Vector1Like>
     JointMotion __mult__(const Eigen::MatrixBase<Vector1Like> & v) const
     {
-      typedef typename Vector1Like::Scalar Scalar;
-      typedef Eigen::Matrix<Scalar, 1, 1, PINOCCHIO_EIGEN_PLAIN_TYPE(Vector1Like)::Options> Vector1;
-
-      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector1Like, Vector1);
+      EIGEN_STATIC_ASSERT_SIZE_1x1(Vector1Like);
       assert(v.size() == 1);
       return JointMotion(v[0]);
     }

--- a/include/pinocchio/src/multibody/joint/joint-prismatic.hxx
+++ b/include/pinocchio/src/multibody/joint/joint-prismatic.hxx
@@ -343,7 +343,10 @@ namespace pinocchio
     template<typename Vector1Like>
     JointMotion __mult__(const Eigen::MatrixBase<Vector1Like> & v) const
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector1Like, 1);
+      typedef typename Vector1Like::Scalar Scalar;
+      typedef Eigen::Matrix<Scalar, 1, 1, PINOCCHIO_EIGEN_PLAIN_TYPE(Vector1Like)::Options> Vector1;
+
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector1Like, Vector1);
       assert(v.size() == 1);
       return JointMotion(v[0]);
     }
@@ -522,7 +525,7 @@ namespace pinocchio
       static inline ReturnType
       run(const Eigen::MatrixBase<M6Like> & Y, const Constraint & /*constraint*/)
       {
-        EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(M6Like, 6, 6);
+        EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(M6Like, context::Matrix6xs);
         return Y.derived().col(Inertia::LINEAR + axis);
       }
     };

--- a/include/pinocchio/src/multibody/joint/joint-revolute-unaligned.hxx
+++ b/include/pinocchio/src/multibody/joint/joint-revolute-unaligned.hxx
@@ -286,10 +286,7 @@ namespace pinocchio
     template<typename Vector1Like>
     JointMotion __mult__(const Eigen::MatrixBase<Vector1Like> & v) const
     {
-      typedef typename Vector1Like::Scalar Scalar;
-      typedef Eigen::Matrix<Scalar, 1, 1, PINOCCHIO_EIGEN_PLAIN_TYPE(Vector1Like)::Options> Vector1;
-
-      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector1Like, Vector1);
+      EIGEN_STATIC_ASSERT_SIZE_1x1(Vector1Like);
       return JointMotion(m_axis, v[0]);
     }
 

--- a/include/pinocchio/src/multibody/joint/joint-revolute-unaligned.hxx
+++ b/include/pinocchio/src/multibody/joint/joint-revolute-unaligned.hxx
@@ -286,7 +286,10 @@ namespace pinocchio
     template<typename Vector1Like>
     JointMotion __mult__(const Eigen::MatrixBase<Vector1Like> & v) const
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector1Like, 1);
+      typedef typename Vector1Like::Scalar Scalar;
+      typedef Eigen::Matrix<Scalar, 1, 1, PINOCCHIO_EIGEN_PLAIN_TYPE(Vector1Like)::Options> Vector1;
+
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector1Like, Vector1);
       return JointMotion(m_axis, v[0]);
     }
 
@@ -469,7 +472,7 @@ namespace pinocchio
 
       static inline ReturnType run(const Eigen::MatrixBase<M6Like> & Y, const Constraint & cru)
       {
-        EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(M6Like, 6, 6);
+        EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(M6Like, context::Matrix6xs);
         return Y.derived().template middleCols<3>(Constraint::ANGULAR) * cru.axis();
       }
     };

--- a/include/pinocchio/src/multibody/joint/joint-revolute.hxx
+++ b/include/pinocchio/src/multibody/joint/joint-revolute.hxx
@@ -627,7 +627,7 @@ namespace pinocchio
       static inline ReturnType
       run(const Eigen::MatrixBase<M6Like> & Y, const Constraint & /*constraint*/)
       {
-        EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(M6Like, 6, 6);
+        EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(M6Like, context::Matrix6xs);
         return Y.col(Inertia::ANGULAR + axis);
       }
     };

--- a/include/pinocchio/src/multibody/joint/joint-spherical-ZYX.hxx
+++ b/include/pinocchio/src/multibody/joint/joint-spherical-ZYX.hxx
@@ -54,13 +54,13 @@ namespace pinocchio
     JointMotionSubspaceSphericalZYXTpl(const Eigen::MatrixBase<Matrix3Like> & subspace)
     : m_S(subspace)
     {
-      EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix3Like, 3, 3);
+      EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix3Like, context::Matrix3x);
     }
 
     template<typename Vector3Like>
     JointMotion __mult__(const Eigen::MatrixBase<Vector3Like> & v) const
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3Like, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3Like, context::Vector3);
       return JointMotion(m_S * v);
     }
 
@@ -236,7 +236,7 @@ namespace pinocchio
   operator*(
     const Eigen::MatrixBase<Matrix6Like> & Y, const JointMotionSubspaceSphericalZYXTpl<S2, O2> & S)
   {
-    EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix6Like, 6, 6);
+      EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix6Like, context::Matrix6xs);
     return Y.derived().template middleCols<3>(Inertia::ANGULAR) * S.angularSubspace();
   }
 

--- a/include/pinocchio/src/multibody/joint/joint-spherical-ZYX.hxx
+++ b/include/pinocchio/src/multibody/joint/joint-spherical-ZYX.hxx
@@ -236,7 +236,7 @@ namespace pinocchio
   operator*(
     const Eigen::MatrixBase<Matrix6Like> & Y, const JointMotionSubspaceSphericalZYXTpl<S2, O2> & S)
   {
-      EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix6Like, context::Matrix6xs);
+    EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix6Like, context::Matrix6xs);
     return Y.derived().template middleCols<3>(Inertia::ANGULAR) * S.angularSubspace();
   }
 

--- a/include/pinocchio/src/multibody/joint/joint-spherical.hxx
+++ b/include/pinocchio/src/multibody/joint/joint-spherical.hxx
@@ -232,7 +232,7 @@ namespace pinocchio
     template<typename Vector3Like>
     JointMotion __mult__(const Eigen::MatrixBase<Vector3Like> & w) const
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3Like, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3Like, context::Vector3);
       return JointMotion(w);
     }
 

--- a/include/pinocchio/src/multibody/joint/joint-translation.hxx
+++ b/include/pinocchio/src/multibody/joint/joint-translation.hxx
@@ -322,7 +322,7 @@ namespace pinocchio
     template<typename Vector3Like>
     JointMotion __mult__(const Eigen::MatrixBase<Vector3Like> & v) const
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3Like, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3Like, context::Vector3);
       return JointMotion(v);
     }
 

--- a/include/pinocchio/src/multibody/joint/joint-universal.hxx
+++ b/include/pinocchio/src/multibody/joint/joint-universal.hxx
@@ -284,7 +284,7 @@ namespace pinocchio
 
       static inline ReturnType run(const Eigen::MatrixBase<M6Like> & Y, const Constraint & cru)
       {
-      EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(M6Like, context::Matrix6xs);
+        EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(M6Like, context::Matrix6xs);
         return Y.derived().template middleCols<3>(Constraint::ANGULAR) * cru.angularSubspace();
       }
     };

--- a/include/pinocchio/src/multibody/joint/joint-universal.hxx
+++ b/include/pinocchio/src/multibody/joint/joint-universal.hxx
@@ -284,7 +284,7 @@ namespace pinocchio
 
       static inline ReturnType run(const Eigen::MatrixBase<M6Like> & Y, const Constraint & cru)
       {
-        EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(M6Like, 6, 6);
+      EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(M6Like, context::Matrix6xs);
         return Y.derived().template middleCols<3>(Constraint::ANGULAR) * cru.angularSubspace();
       }
     };

--- a/include/pinocchio/src/multibody/liegroup/special-euclidean.hxx
+++ b/include/pinocchio/src/multibody/liegroup/special-euclidean.hxx
@@ -53,8 +53,8 @@ namespace pinocchio
       const Eigen::MatrixBase<Vector2Like> & t)
     {
       EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(TangentVector_t, TangentVector);
-      EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix2Like, 2, 2);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector2Like, 2);
+      EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix2Like, Matrix2);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector2Like, Vector2);
 
       typedef typename Matrix2Like::Scalar Scalar;
       const Scalar omega = v(2);
@@ -85,8 +85,8 @@ namespace pinocchio
       const Eigen::MatrixBase<Matrix3Like> & M,
       const AssignmentOperatorType op)
     {
-      EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix2Like, 2, 2);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector2Like, 2);
+      EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix2Like, Matrix2);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector2Like, Vector2);
       PINOCCHIO_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix3Like, M, 3, 3);
       Matrix3Like & Mout = PINOCCHIO_EIGEN_CONST_CAST(Matrix3Like, M);
       typedef typename Matrix3Like::Scalar Scalar;
@@ -122,8 +122,8 @@ namespace pinocchio
       const Eigen::MatrixBase<Vector2Like> & p,
       const Eigen::MatrixBase<TangentVector> & v)
     {
-      EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix2Like, 2, 2);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector2Like, 2);
+      EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix2Like, Matrix2);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector2Like, Vector2);
       EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(TangentVector_t, TangentVector);
 
       TangentVector & vout = PINOCCHIO_EIGEN_CONST_CAST(TangentVector, v);
@@ -153,8 +153,8 @@ namespace pinocchio
       const Eigen::MatrixBase<Vector2Like> & p,
       const Eigen::MatrixBase<JacobianOutLike> & J)
     {
-      EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix2Like, 2, 2);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector2Like, 2);
+      EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix2Like, Matrix2);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector2Like, Vector2);
       EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(JacobianOutLike, JacobianMatrix_t);
 
       JacobianOutLike & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOutLike, J);

--- a/include/pinocchio/src/multibody/liegroup/special-orthogonal.hxx
+++ b/include/pinocchio/src/multibody/liegroup/special-orthogonal.hxx
@@ -53,7 +53,7 @@ namespace pinocchio
     static typename Matrix2Like::Scalar log(const Eigen::MatrixBase<Matrix2Like> & R)
     {
       typedef typename Matrix2Like::Scalar Scalar;
-      EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix2Like, 2, 2);
+      EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix2Like, Matrix2);
 
       const Scalar tr = R.trace();
 
@@ -94,7 +94,7 @@ namespace pinocchio
     static typename Matrix2Like::Scalar Jlog(const Eigen::MatrixBase<Matrix2Like> &)
     {
       typedef typename Matrix2Like::Scalar Scalar;
-      EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix2Like, 2, 2);
+      EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix2Like, Matrix2);
       return Scalar(1);
     }
 

--- a/include/pinocchio/src/spatial/cartesian-axis.hxx
+++ b/include/pinocchio/src/spatial/cartesian-axis.hxx
@@ -95,8 +95,8 @@ namespace pinocchio
   inline void CartesianAxis<0>::cross(
     const Eigen::MatrixBase<V3_in> & vin, const Eigen::MatrixBase<V3_out> & vout)
   {
-    EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(V3_in, 3)
-    EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(V3_out, 3)
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(V3_in, context::Vector3)
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(V3_out, context::Vector3)
     V3_out & vout_ = PINOCCHIO_EIGEN_CONST_CAST(V3_out, vout);
     vout_[0] = 0.;
     vout_[1] = -vin[2];
@@ -108,8 +108,8 @@ namespace pinocchio
   inline void CartesianAxis<1>::cross(
     const Eigen::MatrixBase<V3_in> & vin, const Eigen::MatrixBase<V3_out> & vout)
   {
-    EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(V3_in, 3)
-    EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(V3_out, 3)
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(V3_in, context::Vector3)
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(V3_out, context::Vector3)
     V3_out & vout_ = PINOCCHIO_EIGEN_CONST_CAST(V3_out, vout);
     vout_[0] = vin[2];
     vout_[1] = 0.;
@@ -121,8 +121,8 @@ namespace pinocchio
   inline void CartesianAxis<2>::cross(
     const Eigen::MatrixBase<V3_in> & vin, const Eigen::MatrixBase<V3_out> & vout)
   {
-    EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(V3_in, 3)
-    EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(V3_out, 3)
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(V3_in, context::Vector3)
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(V3_out, context::Vector3)
     V3_out & vout_ = PINOCCHIO_EIGEN_CONST_CAST(V3_out, vout);
     vout_[0] = -vin[1];
     vout_[1] = vin[0];
@@ -134,8 +134,8 @@ namespace pinocchio
   inline void CartesianAxis<0>::alphaCross(
     const Scalar & s, const Eigen::MatrixBase<V3_in> & vin, const Eigen::MatrixBase<V3_out> & vout)
   {
-    EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(V3_in, 3)
-    EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(V3_out, 3)
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(V3_in, context::Vector3)
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(V3_out, context::Vector3)
     V3_out & vout_ = PINOCCHIO_EIGEN_CONST_CAST(V3_out, vout);
     vout_[0] = 0.;
     vout_[1] = -s * vin[2];
@@ -147,8 +147,8 @@ namespace pinocchio
   inline void CartesianAxis<1>::alphaCross(
     const Scalar & s, const Eigen::MatrixBase<V3_in> & vin, const Eigen::MatrixBase<V3_out> & vout)
   {
-    EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(V3_in, 3)
-    EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(V3_out, 3)
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(V3_in, context::Vector3)
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(V3_out, context::Vector3)
     V3_out & vout_ = PINOCCHIO_EIGEN_CONST_CAST(V3_out, vout);
     vout_[0] = s * vin[2];
     vout_[1] = 0.;
@@ -160,8 +160,8 @@ namespace pinocchio
   inline void CartesianAxis<2>::alphaCross(
     const Scalar & s, const Eigen::MatrixBase<V3_in> & vin, const Eigen::MatrixBase<V3_out> & vout)
   {
-    EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(V3_in, 3)
-    EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(V3_out, 3)
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(V3_in, Vector3)
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(V3_out, Vector3)
     V3_out & vout_ = PINOCCHIO_EIGEN_CONST_CAST(V3_out, vout);
     vout_[0] = -s * vin[1];
     vout_[1] = s * vin[0];

--- a/include/pinocchio/src/spatial/force-ref.hxx
+++ b/include/pinocchio/src/spatial/force-ref.hxx
@@ -109,14 +109,14 @@ namespace pinocchio
     template<typename V3>
     void angular_impl(const Eigen::MatrixBase<V3> & w)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(V3, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(V3, Vector3);
       angular_impl() = w;
     }
 
     template<typename V3>
     void linear_impl(const Eigen::MatrixBase<V3> & v)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(V3, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(V3, Vector3);
       linear_impl() = v;
     }
 

--- a/include/pinocchio/src/spatial/force-tpl.hxx
+++ b/include/pinocchio/src/spatial/force-tpl.hxx
@@ -76,8 +76,8 @@ namespace pinocchio
       const Eigen::MatrixBase<ForceVectorLike> & force,
       const Eigen::MatrixBase<TorqueVectorLike> & torque)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(ForceVectorLike, 3);
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(TorqueVectorLike, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ForceVectorLike, Vector3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(TorqueVectorLike, Vector3);
       linear() = force;
       angular() = torque;
     }
@@ -93,7 +93,7 @@ namespace pinocchio
     explicit ForceTpl(const Eigen::MatrixBase<Vector6Like> & f)
     : m_data(f)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector6Like, 6);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector6Like, Vector6);
     }
 
     ///
@@ -200,13 +200,13 @@ namespace pinocchio
     template<typename V3>
     void angular_impl(const Eigen::MatrixBase<V3> & w)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(V3, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(V3, Vector3);
       angular_impl() = w;
     }
     template<typename V3>
     void linear_impl(const Eigen::MatrixBase<V3> & v)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(V3, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(V3, Vector3);
       linear_impl() = v;
     }
 

--- a/include/pinocchio/src/spatial/inertia.hxx
+++ b/include/pinocchio/src/spatial/inertia.hxx
@@ -820,7 +820,7 @@ namespace pinocchio
       const InertiaTpl & I,
       const Eigen::MatrixBase<M6> & Iout)
     {
-      EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(M6, 6, 6);
+      EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(M6, Matrix6);
       M6 & Iout_ = PINOCCHIO_EIGEN_CONST_CAST(M6, Iout);
 
       // Block 1,1
@@ -854,7 +854,7 @@ namespace pinocchio
       const InertiaTpl & I,
       const Eigen::MatrixBase<M6> & Iout)
     {
-      EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(M6, 6, 6);
+      EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(M6, Matrix6);
       M6 & Iout_ = PINOCCHIO_EIGEN_CONST_CAST(M6, Iout);
 
       // Block 1,1

--- a/include/pinocchio/src/spatial/motion-ref.hxx
+++ b/include/pinocchio/src/spatial/motion-ref.hxx
@@ -132,14 +132,14 @@ namespace pinocchio
     template<typename V3>
     void angular_impl(const Eigen::MatrixBase<V3> & w)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(V3, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(V3, Vector3);
       angular_impl() = w;
     }
 
     template<typename V3>
     void linear_impl(const Eigen::MatrixBase<V3> & v)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(V3, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(V3, Vector3);
       linear_impl() = v;
     }
 

--- a/include/pinocchio/src/spatial/motion-tpl.hxx
+++ b/include/pinocchio/src/spatial/motion-tpl.hxx
@@ -175,13 +175,13 @@ namespace pinocchio
     template<typename V3>
     void angular_impl(const Eigen::MatrixBase<V3> & w)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(V3, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(V3, Vector3);
       angular_impl() = w;
     }
     template<typename V3>
     void linear_impl(const Eigen::MatrixBase<V3> & v)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(V3, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(V3, Vector3);
       linear_impl() = v;
     }
 

--- a/include/pinocchio/src/spatial/se3-tpl.hxx
+++ b/include/pinocchio/src/spatial/se3-tpl.hxx
@@ -66,14 +66,17 @@ namespace pinocchio
     : rot(quat.matrix())
     , trans(trans)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3Like, 3)
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3Like, Vector3)
     }
 
     template<typename Matrix3Like, typename Vector3Like>
     SE3Tpl(const Eigen::MatrixBase<Matrix3Like> & R, const Eigen::MatrixBase<Vector3Like> & trans)
     : rot(R)
-    , trans(trans){EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3Like, 3)
-                     EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix3Like, 3, 3)}
+    , trans(trans)
+    {
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3Like, Vector3)
+      EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix3Like, Matrix3);
+    }
 
     SE3Tpl(const SE3Tpl & other)
     {
@@ -91,7 +94,7 @@ namespace pinocchio
     : rot(m.template block<3, 3>(LINEAR, LINEAR))
     , trans(m.template block<3, 1>(LINEAR, ANGULAR))
     {
-      EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix4Like, 4, 4);
+      EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix4Like, Matrix4);
     }
 
     explicit SE3Tpl(int)

--- a/include/pinocchio/src/spatial/skew.hxx
+++ b/include/pinocchio/src/spatial/skew.hxx
@@ -25,8 +25,8 @@ namespace pinocchio
   template<typename Vector3, typename Matrix3>
   inline void skew(const Eigen::MatrixBase<Vector3> & v, const Eigen::MatrixBase<Matrix3> & M)
   {
-    EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3, 3);
-    EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix3, 3, 3);
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3, context::Vector3);
+    EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix3, context::Matrix3x);
 
     Matrix3 & M_ = PINOCCHIO_EIGEN_CONST_CAST(Matrix3, M);
     typedef typename Matrix3::RealScalar Scalar;
@@ -71,7 +71,7 @@ namespace pinocchio
   inline void
   addSkew(const Eigen::MatrixBase<Vector3Like> & v, const Eigen::MatrixBase<Matrix3Like> & M)
   {
-    EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3Like, 3);
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3Like, context::Vector3);
     PINOCCHIO_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix3Like, M, 3, 3);
 
     Matrix3Like & M_ = PINOCCHIO_EIGEN_CONST_CAST(Matrix3Like, M);
@@ -97,8 +97,8 @@ namespace pinocchio
   inline void unSkew(const Eigen::MatrixBase<Matrix3> & M, const Eigen::MatrixBase<Vector3> & v)
   {
     typedef typename Vector3::RealScalar Scalar;
-    EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3, 3);
-    EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix3, 3, 3);
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3, context::Vector3);
+    EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix3, context::Matrix3x);
 
     Vector3 & v_ = PINOCCHIO_EIGEN_CONST_CAST(Vector3, v);
 
@@ -138,8 +138,8 @@ namespace pinocchio
   void alphaSkew(
     const Scalar alpha, const Eigen::MatrixBase<Vector3> & v, const Eigen::MatrixBase<Matrix3> & M)
   {
-    EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3, 3);
-    EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix3, 3, 3);
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3, context::Vector3);
+    EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix3, context::Matrix3x);
 
     Matrix3 & M_ = PINOCCHIO_EIGEN_CONST_CAST(Matrix3, M);
     typedef typename Matrix3::RealScalar RealScalar;
@@ -188,9 +188,9 @@ namespace pinocchio
     const Eigen::MatrixBase<V2> & v,
     const Eigen::MatrixBase<Matrix3> & C)
   {
-    EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(V1, 3);
-    EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(V2, 3);
-    EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix3, 3, 3);
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(V1, context::Vector3);
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(V2, context::Vector3);
+    EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix3, context::Matrix3x);
 
     Matrix3 & C_ = PINOCCHIO_EIGEN_CONST_CAST(Matrix3, C);
     typedef typename Matrix3::RealScalar Scalar;
@@ -234,7 +234,7 @@ namespace pinocchio
     const Eigen::MatrixBase<Matrix3xIn> & Min,
     const Eigen::MatrixBase<Matrix3xOut> & Mout)
   {
-    EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3, 3);
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3, context::Vector3);
     EIGEN_STATIC_ASSERT(
       Matrix3xIn::RowsAtCompileTime == 3, THIS_METHOD_IS_ONLY_FOR_MATRICES_OF_A_SPECIFIC_SIZE);
     EIGEN_STATIC_ASSERT(

--- a/include/pinocchio/src/spatial/symmetric3.hxx
+++ b/include/pinocchio/src/spatial/symmetric3.hxx
@@ -123,7 +123,7 @@ namespace pinocchio
     template<typename Vector3Like>
     void setDiagonal(const Eigen::MatrixBase<Vector3Like> & diag)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3Like, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3Like, Vector3);
       m_data[0] = diag[0];
       m_data[2] = diag[1];
       m_data[5] = diag[2];
@@ -350,8 +350,8 @@ namespace pinocchio
       const Symmetric3Tpl & S3,
       const Eigen::MatrixBase<Matrix3> & M)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3, 3);
-      EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix3, 3, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3, context::Vector3);
+      EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix3, context::Matrix3x);
 
       const Scalar & a = S3.data()[0];
       const Scalar & b = S3.data()[1];
@@ -411,8 +411,8 @@ namespace pinocchio
       const Symmetric3Tpl & S3,
       const Eigen::MatrixBase<Matrix3> & M)
     {
-      EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Vector3, 3);
-      EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix3, 3, 3);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Vector3, context::Vector3);
+      EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix3, context::Matrix3x);
 
       const Scalar & a = S3.data()[0];
       const Scalar & b = S3.data()[1];
@@ -558,7 +558,7 @@ namespace pinocchio
     template<typename D>
     Symmetric3Tpl rotate(const Eigen::MatrixBase<D> & R) const
     {
-      EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(D, 3, 3);
+      EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(D, context::Matrix3x);
       assert(
         check_expression_if_real<Scalar>(isUnitary(R.transpose() * R))
         && "R is not a Unitary matrix");


### PR DESCRIPTION
Thanks for taking the time to make and fill out this pull request!

## Description

<!--
Made the following changes : 
EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE => EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE
EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE => EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE

The previous macros did not work with dynamic vector and matrix, this fix ensures retrocompatibility
-->

## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code 
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the doxygen documentation
- [ ] I have added tests that prove my fix or feature works
- [ ] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [ ] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
