### PR TITLE
multibody: rollback and use lastChild

### DIFF
--- a/include/pinocchio/bindings/python/multibody/data.hpp
+++ b/include/pinocchio/bindings/python/multibody/data.hpp
@@ -321,8 +321,9 @@ namespace pinocchio
         // to std::vector<Vector3d> binding.
         // Because current eigenpy API doesn't support adding attribute to already
         // registered type, we must add them in the __init__.py
-        if (eigenpy::register_symbolic_link_to_registered_type<StdVec_Vector3>(
-              DefPickleStdVectorVisitor<StdVec_Vector3>()))
+        if (
+          eigenpy::register_symbolic_link_to_registered_type<StdVec_Vector3>(
+            DefPickleStdVectorVisitor<StdVec_Vector3>()))
         {
           bp::scope().attr("StdVec_Vector3") = bp::scope().attr("StdVec_Vec3s"); // alias
         }

--- a/include/pinocchio/bindings/python/multibody/data.hpp
+++ b/include/pinocchio/bindings/python/multibody/data.hpp
@@ -318,8 +318,9 @@ namespace pinocchio
         // to std::vector<Vector3d> binding.
         // Because current eigenpy API doesn't support adding attribute to already
         // registered type, we must add them in the __init__.py
-        if (eigenpy::register_symbolic_link_to_registered_type<StdVec_Vector3>(
-              DefPickleStdVectorVisitor<StdVec_Vector3>()))
+        if (
+          eigenpy::register_symbolic_link_to_registered_type<StdVec_Vector3>(
+            DefPickleStdVectorVisitor<StdVec_Vector3>()))
         {
           bp::scope().attr("StdVec_Vector3") = bp::scope().attr("StdVec_Vec3s"); // alias
         }

--- a/include/pinocchio/bindings/python/multibody/data.hpp
+++ b/include/pinocchio/bindings/python/multibody/data.hpp
@@ -85,6 +85,8 @@ namespace pinocchio
   PINOCCHIO_ADD_PROPERTY_READONLY_BYVALUE(Data, NAME, DOC)
 
       /* --- Exposing C++ API to python through the handler ----------------- */
+      PINOCCHIO_COMPILER_DIAGNOSTIC_PUSH
+      PINOCCHIO_COMPILER_DIAGNOSTIC_IGNORED_DEPRECECATED_DECLARATIONS
       template<class PyClass>
       void visit(PyClass & cl) const
       {
@@ -288,6 +290,7 @@ namespace pinocchio
 
         bp::register_ptr_to_python<std::shared_ptr<Data>>();
       }
+      PINOCCHIO_COMPILER_DIAGNOSTIC_POP
 
       /* --- Expose --------------------------------------------------------- */
       static void expose()
@@ -318,9 +321,8 @@ namespace pinocchio
         // to std::vector<Vector3d> binding.
         // Because current eigenpy API doesn't support adding attribute to already
         // registered type, we must add them in the __init__.py
-        if (
-          eigenpy::register_symbolic_link_to_registered_type<StdVec_Vector3>(
-            DefPickleStdVectorVisitor<StdVec_Vector3>()))
+        if (eigenpy::register_symbolic_link_to_registered_type<StdVec_Vector3>(
+              DefPickleStdVectorVisitor<StdVec_Vector3>()))
         {
           bp::scope().attr("StdVec_Vector3") = bp::scope().attr("StdVec_Vec3s"); // alias
         }

--- a/include/pinocchio/bindings/python/multibody/data.hpp
+++ b/include/pinocchio/bindings/python/multibody/data.hpp
@@ -149,6 +149,7 @@ namespace pinocchio
                "C(q,v)v")
           .ADD_DATA_PROPERTY(g, "Vector of generalized gravity (dim model.nv).")
           .ADD_DATA_PROPERTY(Fcrb, "Spatial forces set, used in CRBA")
+          .ADD_DATA_PROPERTY(lastChild, "Index of the last child (for CRBA)")
           .ADD_DATA_PROPERTY(nvSubtree, "Dimension of the subtree motion space (for CRBA)")
           .ADD_DATA_PROPERTY(U, "Joint Inertia square root (upper triangle)")
           .ADD_DATA_PROPERTY(D, "Diagonal of UDUT inertia decomposition")
@@ -317,9 +318,8 @@ namespace pinocchio
         // to std::vector<Vector3d> binding.
         // Because current eigenpy API doesn't support adding attribute to already
         // registered type, we must add them in the __init__.py
-        if (
-          eigenpy::register_symbolic_link_to_registered_type<StdVec_Vector3>(
-            DefPickleStdVectorVisitor<StdVec_Vector3>()))
+        if (eigenpy::register_symbolic_link_to_registered_type<StdVec_Vector3>(
+              DefPickleStdVectorVisitor<StdVec_Vector3>()))
         {
           bp::scope().attr("StdVec_Vector3") = bp::scope().attr("StdVec_Vec3s"); // alias
         }

--- a/include/pinocchio/src/algorithm/check-data.hxx
+++ b/include/pinocchio/src/algorithm/check-data.hxx
@@ -14,6 +14,8 @@
 namespace pinocchio
 {
 
+  PINOCCHIO_COMPILER_DIAGNOSTIC_PUSH
+  PINOCCHIO_COMPILER_DIAGNOSTIC_IGNORED_DEPRECECATED_DECLARATIONS
   template<typename Scalar, int Options, template<typename, int> class JointCollectionTpl>
   inline bool checkData(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
@@ -165,5 +167,6 @@ namespace pinocchio
 #undef CHECK_DATA
     return true;
   }
+  PINOCCHIO_COMPILER_DIAGNOSTIC_POP
 
 } // namespace pinocchio

--- a/include/pinocchio/src/algorithm/check-data.hxx
+++ b/include/pinocchio/src/algorithm/check-data.hxx
@@ -76,6 +76,7 @@ namespace pinocchio
 
     CHECK_DATA((int)data.oMf.size() == model.nframes);
 
+    CHECK_DATA((int)data.lastChild.size() == model.njoints);
     CHECK_DATA((int)data.nvSubtree.size() == model.njoints);
     CHECK_DATA((int)data.parents_fromRow.size() == model.nvExtended);
     CHECK_DATA((int)data.mimic_parents_fromRow.size() == model.nvExtended);

--- a/include/pinocchio/src/multibody/data.hxx
+++ b/include/pinocchio/src/multibody/data.hxx
@@ -307,6 +307,9 @@ namespace pinocchio
     /// \brief Spatial forces set, used in CRBA and CCRBA
     std::vector<Matrix6x> Fcrb;
 
+    /// \brief Index of the last child (for CRBA)
+    PINOCCHIO_DEPRECATED std::vector<int> lastChild;
+
     /// \brief Dimension of the subtree motion space (for CRBA)
     std::vector<int> nvSubtree;
 
@@ -621,6 +624,8 @@ namespace pinocchio
     }
 
   private:
+    PINOCCHIO_DEPRECATED void computeLastChild(const Model & model);
+    PINOCCHIO_DEPRECATED void computeLastChildImpl(const Model & model);
     void computeNvSubtree(const Model & model);
     void computeParents_fromRow(const Model & model);
     void computeSupports_fromRow(const Model & model);
@@ -693,6 +698,7 @@ namespace pinocchio
   , dhg(Force::Zero())
   , Ig(Inertia::Zero())
   , Fcrb((std::size_t)model.njoints, Matrix6x::Zero(6, model.nv))
+  , lastChild((std::size_t)model.njoints, -1)
   , nvSubtree((std::size_t)model.njoints, 0)
   , start_idx_v_fromRow((std::size_t)model.nvExtended, -1)
   , end_idx_v_fromRow((std::size_t)model.nvExtended, -1)
@@ -789,6 +795,8 @@ namespace pinocchio
     M.setZero();
     Minv.setZero();
 
+    computeLastChildImpl(model);
+
     computeNvSubtree(model);
 
     /* Init for Cholesky */
@@ -803,6 +811,61 @@ namespace pinocchio
     d2tau_dvdv.setZero();
     d2tau_dqdv.setZero();
     d2tau_dadq.setZero();
+  }
+
+  template<typename Scalar, int Options, template<typename, int> class JointCollectionTpl>
+  inline void DataTpl<Scalar, Options, JointCollectionTpl>::computeLastChild(const Model & model)
+  {
+    typedef typename Model::Index Index;
+
+    std::fill(lastChild.begin(), lastChild.end(), -1);
+    for (int i = model.njoints - 1; i >= 0; --i)
+    {
+      if (lastChild[(Index)i] == -1)
+        lastChild[(Index)i] = i;
+      const Index & parent = model.parents[(Index)i];
+
+      lastChild[parent] = std::max<int>(lastChild[(Index)i], lastChild[parent]);
+
+      nvSubtree[(Index)i] += model.joints[(Index)i].nv();
+      nvSubtree[parent] += nvSubtree[(Index)i];
+    }
+    // fill mimic data
+    for (const JointIndex mimicking_id : model.mimicking_joints)
+    {
+      const auto & mimicking_sub = model.subtrees[mimicking_id];
+      size_t j = 1;
+      bool found = false;
+      for (; j < mimicking_sub.size(); j++)
+      {
+        if (model.nvs[mimicking_sub[j]] != 0)
+        {
+          found = true;
+          break;
+        }
+      }
+      if (mimicking_sub.size() == 1 || !found)
+        mimic_subtree_joint.push_back(0);
+      else
+        mimic_subtree_joint.push_back(mimicking_sub[j]);
+    }
+  }
+
+  template<typename Scalar, int Options, template<typename, int> class JointCollectionTpl>
+  inline void
+  DataTpl<Scalar, Options, JointCollectionTpl>::computeLastChildImpl(const Model & model)
+  {
+    typedef typename Model::Index Index;
+
+    std::fill(lastChild.begin(), lastChild.end(), -1);
+    for (int i = model.njoints - 1; i >= 0; --i)
+    {
+      if (lastChild[(Index)i] == -1)
+        lastChild[(Index)i] = i;
+      const Index & parent = model.parents[(Index)i];
+
+      lastChild[parent] = std::max<int>(lastChild[(Index)i], lastChild[parent]);
+    }
   }
 
   template<typename Scalar, int Options, template<typename, int> class JointCollectionTpl>
@@ -961,7 +1024,8 @@ namespace pinocchio
       && data1.oYaba_augmented == data2.oYaba_augmented && data1.oL == data2.oL
       && data1.oK == data2.oK && data1.u == data2.u && data1.Ag == data2.Ag
       && data1.dAg == data2.dAg && data1.hg == data2.hg && data1.dhg == data2.dhg
-      && data1.Ig == data2.Ig && data1.Fcrb == data2.Fcrb && data1.nvSubtree == data2.nvSubtree
+      && data1.Ig == data2.Ig && data1.Fcrb == data2.Fcrb && data1.lastChild == data2.lastChild
+      && data1.nvSubtree == data2.nvSubtree
       && data1.start_idx_v_fromRow == data2.start_idx_v_fromRow
       && data1.end_idx_v_fromRow == data2.end_idx_v_fromRow && data1.U == data2.U
       && data1.D == data2.D && data1.Dinv == data2.Dinv

--- a/include/pinocchio/src/multibody/data.hxx
+++ b/include/pinocchio/src/multibody/data.hxx
@@ -624,8 +624,7 @@ namespace pinocchio
     }
 
   private:
-    PINOCCHIO_DEPRECATED void computeLastChild(const Model & model);
-    PINOCCHIO_DEPRECATED void computeLastChildImpl(const Model & model);
+    void computeLastChild(const Model & model); // TODO Remove when lastChild is removed
     void computeNvSubtree(const Model & model);
     void computeParents_fromRow(const Model & model);
     void computeSupports_fromRow(const Model & model);
@@ -642,6 +641,8 @@ namespace pinocchio
 namespace pinocchio
 {
 
+  PINOCCHIO_COMPILER_DIAGNOSTIC_PUSH
+  PINOCCHIO_COMPILER_DIAGNOSTIC_IGNORED_DEPRECECATED_DECLARATIONS
   template<typename Scalar, int Options, template<typename, int> class JointCollectionTpl>
   DataTpl<Scalar, Options, JointCollectionTpl>::DataTpl(const Model & model)
   : q_in(neutral(model))
@@ -795,7 +796,7 @@ namespace pinocchio
     M.setZero();
     Minv.setZero();
 
-    computeLastChildImpl(model);
+    computeLastChild(model);
 
     computeNvSubtree(model);
 
@@ -812,7 +813,10 @@ namespace pinocchio
     d2tau_dqdv.setZero();
     d2tau_dadq.setZero();
   }
+  PINOCCHIO_COMPILER_DIAGNOSTIC_POP
 
+  PINOCCHIO_COMPILER_DIAGNOSTIC_PUSH
+  PINOCCHIO_COMPILER_DIAGNOSTIC_IGNORED_DEPRECECATED_DECLARATIONS
   template<typename Scalar, int Options, template<typename, int> class JointCollectionTpl>
   inline void DataTpl<Scalar, Options, JointCollectionTpl>::computeLastChild(const Model & model)
   {
@@ -826,47 +830,9 @@ namespace pinocchio
       const Index & parent = model.parents[(Index)i];
 
       lastChild[parent] = std::max<int>(lastChild[(Index)i], lastChild[parent]);
-
-      nvSubtree[(Index)i] += model.joints[(Index)i].nv();
-      nvSubtree[parent] += nvSubtree[(Index)i];
-    }
-    // fill mimic data
-    for (const JointIndex mimicking_id : model.mimicking_joints)
-    {
-      const auto & mimicking_sub = model.subtrees[mimicking_id];
-      size_t j = 1;
-      bool found = false;
-      for (; j < mimicking_sub.size(); j++)
-      {
-        if (model.nvs[mimicking_sub[j]] != 0)
-        {
-          found = true;
-          break;
-        }
-      }
-      if (mimicking_sub.size() == 1 || !found)
-        mimic_subtree_joint.push_back(0);
-      else
-        mimic_subtree_joint.push_back(mimicking_sub[j]);
     }
   }
-
-  template<typename Scalar, int Options, template<typename, int> class JointCollectionTpl>
-  inline void
-  DataTpl<Scalar, Options, JointCollectionTpl>::computeLastChildImpl(const Model & model)
-  {
-    typedef typename Model::Index Index;
-
-    std::fill(lastChild.begin(), lastChild.end(), -1);
-    for (int i = model.njoints - 1; i >= 0; --i)
-    {
-      if (lastChild[(Index)i] == -1)
-        lastChild[(Index)i] = i;
-      const Index & parent = model.parents[(Index)i];
-
-      lastChild[parent] = std::max<int>(lastChild[(Index)i], lastChild[parent]);
-    }
-  }
+  PINOCCHIO_COMPILER_DIAGNOSTIC_POP
 
   template<typename Scalar, int Options, template<typename, int> class JointCollectionTpl>
   inline void DataTpl<Scalar, Options, JointCollectionTpl>::computeNvSubtree(const Model & model)
@@ -999,6 +965,8 @@ namespace pinocchio
     }
   }
 
+  PINOCCHIO_COMPILER_DIAGNOSTIC_PUSH
+  PINOCCHIO_COMPILER_DIAGNOSTIC_IGNORED_DEPRECECATED_DECLARATIONS
   template<typename Scalar, int Options, template<typename, int> class JointCollectionTpl>
   bool operator==(
     const DataTpl<Scalar, Options, JointCollectionTpl> & data1,
@@ -1081,6 +1049,7 @@ namespace pinocchio
 
     return value;
   }
+  PINOCCHIO_COMPILER_DIAGNOSTIC_POP
 
   template<typename Scalar, int Options, template<typename, int> class JointCollectionTpl>
   bool operator!=(

--- a/include/pinocchio/src/serialization/data.hxx
+++ b/include/pinocchio/src/serialization/data.hxx
@@ -17,6 +17,8 @@ namespace boost
 {
   namespace serialization
   {
+    PINOCCHIO_COMPILER_DIAGNOSTIC_PUSH
+    PINOCCHIO_COMPILER_DIAGNOSTIC_IGNORED_DEPRECECATED_DECLARATIONS
     template<
       class Archive,
       typename Scalar,
@@ -161,6 +163,7 @@ namespace boost
       PINOCCHIO_MAKE_DATA_NVP(ar, data, projected_joint_cross_coupling);
       PINOCCHIO_MAKE_DATA_NVP(ar, data, joint_apparent_inertia);
     }
+    PINOCCHIO_COMPILER_DIAGNOSTIC_POP
 
   } // namespace serialization
 } // namespace boost

--- a/include/pinocchio/src/serialization/data.hxx
+++ b/include/pinocchio/src/serialization/data.hxx
@@ -83,6 +83,7 @@ namespace boost
       PINOCCHIO_MAKE_DATA_NVP(ar, data, dhg);
       PINOCCHIO_MAKE_DATA_NVP(ar, data, Ig);
       PINOCCHIO_MAKE_DATA_NVP(ar, data, Fcrb);
+      PINOCCHIO_MAKE_DATA_NVP(ar, data, lastChild);
       PINOCCHIO_MAKE_DATA_NVP(ar, data, nvSubtree);
       PINOCCHIO_MAKE_DATA_NVP(ar, data, start_idx_v_fromRow);
       PINOCCHIO_MAKE_DATA_NVP(ar, data, end_idx_v_fromRow);


### PR DESCRIPTION
Thanks for taking the time to make and fill out this pull request!

## Description
LastChild instance was removed from multibody/data/hxx, instead of being deprecated. It has been put back in the code and the macro PINOCCHIO_DEPRECATED has been added

## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the doxygen documentation
- [ ] I have added tests that prove my fix or feature works
- [ ] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [ ] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
