### PR TITLE
Remove coal timer

### DIFF
--- a/include/pinocchio/algorithm/solvers/admm-solver.hpp
+++ b/include/pinocchio/algorithm/solvers/admm-solver.hpp
@@ -142,6 +142,8 @@ namespace pinocchio
     typedef internal::ADMMUpdateRuleContainerTpl<Scalar> ADMMUpdateRuleContainer;
 
     using Base::reset;
+    using Base::timerStart;
+    using Base::timerStop;
 
     /// \brief Default constructor.
     /// \note The user can give `max_problem_size` to preallocate maximum problem sizes data.
@@ -191,11 +193,6 @@ namespace pinocchio
       m_workspace.reset();
       m_is_valid = false;
     }
-
-#ifdef PINOCCHIO_WITH_COLLISION
-    /// \brief Timer for the `solve` method
-    using Base::timer;
-#endif // PINOCCHIO_WITH_COLLISION
 
     /// \brief Per-iteration stats of the ADMM solver.
     ADMMSolverStats stats;

--- a/include/pinocchio/algorithm/solvers/constraint-solver-base.hpp
+++ b/include/pinocchio/algorithm/solvers/constraint-solver-base.hpp
@@ -8,15 +8,13 @@
 #include <limits>
 #include <vector>
 #include <optional>
+#include <chrono>
 
 #include "pinocchio/macros.hpp"
 #include "pinocchio/fwd.hpp"
 #include "pinocchio/utils/check.hpp"
 #include "pinocchio/algorithm/delassus-operator.hpp"
 
-#ifdef PINOCCHIO_WITH_COLLISION
-  #include <coal/timings.h>
-#endif // PINOCCHIO_WITH_COLLISION
 // IWYU pragma: end_keep
 
 // IWYU pragma: begin_exports

--- a/include/pinocchio/algorithm/solvers/pgs-solver.hpp
+++ b/include/pinocchio/algorithm/solvers/pgs-solver.hpp
@@ -70,6 +70,8 @@ namespace pinocchio
     typedef PGSSolverStatsTpl<Scalar> PGSSolverStats;
 
     using Base::reset;
+    using Base::timerStart;
+    using Base::timerStop;
 
     /// \brief Default constructor.
     /// \note The user can give `max_problem_size` to preallocate maximum problem sizes data.
@@ -119,11 +121,6 @@ namespace pinocchio
       m_workspace.reset();
       m_is_valid = false;
     }
-
-#ifdef PINOCCHIO_WITH_COLLISION
-    /// \brief Timer for the `solve` method
-    using Base::timer;
-#endif // PINOCCHIO_WITH_COLLISION
 
     /// \brief Per-iteration stats of the PGS solver.
     PGSSolverStats stats;

--- a/include/pinocchio/bindings/python/algorithm/constraint-solver-base.hpp
+++ b/include/pinocchio/bindings/python/algorithm/constraint-solver-base.hpp
@@ -187,11 +187,9 @@ namespace pinocchio
       {
         cl.def("reset", &Solver::reset, bp::arg("self"), "Reset the solver to its initial state.");
 
-#ifdef PINOCCHIO_WITH_COLLISION
         cl.def(
-          "getCPUTimes", &Solver::getCPUTimes, bp::arg("self"),
-          "Return the CPU time breakdown of the last solve call.");
-#endif // PINOCCHIO_WITH_COLLISION
+          "getElapsedTime", &Solver::getElapsedTime, bp::arg("self"),
+          "Return last solve call elapsed time in microseconds.");
       }
     }; // struct ConstraintSolverBasePythonVisitor
 

--- a/include/pinocchio/src/algorithm/solvers/admm-solver.hxx
+++ b/include/pinocchio/src/algorithm/solvers/admm-solver.hxx
@@ -80,12 +80,10 @@ namespace pinocchio
     // -- init of internals done - the solver is now marked as reset
     m_is_valid = false;
 
-#ifdef PINOCCHIO_WITH_COLLISION
     if (settings.measure_timings)
     {
-      timer.start();
+      timerStart();
     }
-#endif // PINOCCHIO_WITH_COLLISION
 
     // Check NCP/CCP conditions. If they are satisfied, don't run the solver.
     // -- always primaly feasible as y is projected onto the constraints
@@ -479,12 +477,10 @@ namespace pinocchio
       }
     }
 
-#ifdef PINOCCHIO_WITH_COLLISION
     if (settings.measure_timings)
     {
-      timer.stop();
+      timerStop();
     }
-#endif // PINOCCHIO_WITH_COLLISION
 
     if (settings.stat_record)
     {

--- a/include/pinocchio/src/algorithm/solvers/constraint-solver-base.hxx
+++ b/include/pinocchio/src/algorithm/solvers/constraint-solver-base.hxx
@@ -341,10 +341,9 @@ namespace pinocchio
     typedef typename traits<Derived>::SolverSettings SolverSettings;
     typedef typename traits<Derived>::SolverResult SolverResult;
 
-#ifdef PINOCCHIO_WITH_COLLISION
-    typedef coal::CPUTimes CPUTimes;
-    typedef coal::Timer Timer;
-#endif // PINOCCHIO_WITH_COLLISION
+    using clock = std::chrono::steady_clock;
+    using time_point = clock::time_point;
+    using duration = std::chrono::duration<double, std::micro>;
 
     /// \brief Cast to Derived.
     Derived & derived()
@@ -355,14 +354,6 @@ namespace pinocchio
     const Derived & derived() const
     {
       return static_cast<const Derived &>(*this);
-    }
-
-    /// \brief Default constructor
-    ConstraintSolverBase()
-#ifdef PINOCCHIO_WITH_COLLISION
-    : timer(false)
-#endif // PINOCCHIO_WITH_COLLISION
-    {
     }
 
     /// \brief Solve the constrained problem composed of problem data (G,g,constraint_models,
@@ -399,24 +390,28 @@ namespace pinocchio
     /// \brief Reset the solver as if it never ran.
     void reset()
     {
-#ifdef PINOCCHIO_WITH_COLLISION
-      timer.stop();
-#endif
-
       derived().resetImpl();
     }
 
-#ifdef PINOCCHIO_WITH_COLLISION
-    CPUTimes getCPUTimes() const
+    /// \brief Last solve call elapsed time in microseconds.
+    double getElapsedTime() const
     {
-      return timer.elapsed();
+      return timer_duration.count();
     }
-#endif // PINOCCHIO_WITH_COLLISION
 
   protected:
-#ifdef PINOCCHIO_WITH_COLLISION
-    Timer timer;
-#endif // PINOCCHIO_WITH_COLLISION
+    void timerStart()
+    {
+      timer_start = clock::now();
+    }
+
+    void timerStop()
+    {
+      timer_duration = clock::now() - timer_start;
+    }
+
+    time_point timer_start;
+    duration timer_duration;
 
   }; // struct ConstraintSolverBaseTpl
 

--- a/include/pinocchio/src/algorithm/solvers/pgs-solver.hxx
+++ b/include/pinocchio/src/algorithm/solvers/pgs-solver.hxx
@@ -658,12 +658,10 @@ namespace pinocchio
     // the solver can now be marked as reset
     m_is_valid = false;
 
-#ifdef PINOCCHIO_WITH_COLLISION
     if (settings.measure_timings)
     {
-      timer.start();
+      timerStart();
     }
-#endif // PINOCCHIO_WITH_COLLISION
 
     bool abs_prec_reached = false;
     bool rel_prec_reached = false;
@@ -767,9 +765,10 @@ namespace pinocchio
       x_previous_norm_inf = x_norm_inf;
     }
 
-#ifdef PINOCCHIO_WITH_COLLISION
-    timer.stop();
-#endif // PINOCCHIO_WITH_COLLISION
+    if (settings.measure_timings)
+    {
+      timerStop();
+    }
 
     // Retrieve solution
     res.x = ws.x;

--- a/pixi.toml
+++ b/pixi.toml
@@ -10,8 +10,8 @@ preview = ["pixi-build"]
 
 [dependencies]
 ccache = ">=4.9.1"
-cmake = ">=3.10"
 cxx-compiler = ">=1.7.0"
+cmake = ">=3.10"
 ninja = ">=1.11"
 pkg-config = ">=0.29.2"
 doxygen = ">=1.12.0"


### PR DESCRIPTION
## Description

Use `std::chrono` instead of `coal::Timer` to simplify the dependency tree.

## Checklist

- [ ] I have run `pre-commit run --all-files` or `pixi run lint`
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the doxygen documentation
- [ ] I have added tests that prove my fix or feature works
- [ ] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [ ] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
