### PR TITLE
Sfinae safe

### DIFF
--- a/include/pinocchio/algorithm/joint-configuration.hpp
+++ b/include/pinocchio/algorithm/joint-configuration.hpp
@@ -1237,13 +1237,15 @@ namespace pinocchio
    * @return     Whether the configurations are equivalent or not, within the given precision.
    *
    */
+
   template<
     typename LieGroup_t,
     typename Scalar,
     int Options,
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorIn1,
-    typename ConfigVectorIn2>
+    typename ConfigVectorIn2,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int> = 0>
   bool isSameConfiguration(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorIn1> & q1,

--- a/include/pinocchio/algorithm/joint-configuration.hpp
+++ b/include/pinocchio/algorithm/joint-configuration.hpp
@@ -71,7 +71,8 @@ namespace pinocchio
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorType,
     typename TangentVectorType,
-    typename ReturnType>
+    typename ReturnType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int> = 0>
   void integrate(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorType> & q,
@@ -131,7 +132,8 @@ namespace pinocchio
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorIn1,
     typename ConfigVectorIn2,
-    typename ReturnType>
+    typename ReturnType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int> = 0>
   void interpolate(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorIn1> & q0,
@@ -194,7 +196,8 @@ namespace pinocchio
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorIn1,
     typename ConfigVectorIn2,
-    typename ReturnType>
+    typename ReturnType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int> = 0>
   void difference(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorIn1> & q0,
@@ -254,7 +257,8 @@ namespace pinocchio
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorIn1,
     typename ConfigVectorIn2,
-    typename ReturnType>
+    typename ReturnType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int> = 0>
   void squaredDistance(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorIn1> & q0,
@@ -315,7 +319,8 @@ namespace pinocchio
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorIn1,
     typename ConfigVectorIn2,
-    typename ReturnType>
+    typename ReturnType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int> = 0>
   void randomConfiguration(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorIn1> & lowerLimits,
@@ -374,7 +379,8 @@ namespace pinocchio
     typename Scalar,
     int Options,
     template<typename, int> class JointCollectionTpl,
-    typename ReturnType>
+    typename ReturnType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int> = 0>
   void neutral(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ReturnType> & qout);
@@ -434,7 +440,8 @@ namespace pinocchio
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorType,
     typename TangentVectorType,
-    typename JacobianMatrixType>
+    typename JacobianMatrixType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int> = 0>
   void dIntegrate(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorType> & q,
@@ -558,7 +565,8 @@ namespace pinocchio
     int Options,
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorType,
-    typename TangentMapMatrixType>
+    typename TangentMapMatrixType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int> = 0>
   void tangentMap(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorType> & q,
@@ -675,7 +683,8 @@ namespace pinocchio
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorType,
     typename MatrixInType,
-    typename MatrixOutType>
+    typename MatrixOutType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int> = 0>
   void tangentMapProduct(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorType> & q,
@@ -738,7 +747,8 @@ namespace pinocchio
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorType,
     typename MatrixInType,
-    typename MatrixOutType>
+    typename MatrixOutType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int> = 0>
   void tangentMapTransposeProduct(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorType> & q,
@@ -813,7 +823,8 @@ namespace pinocchio
     typename ConfigVectorType,
     typename TangentVectorType,
     typename JacobianMatrixType1,
-    typename JacobianMatrixType2>
+    typename JacobianMatrixType2,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int> = 0>
   void dIntegrateTransport(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorType> & q,
@@ -901,7 +912,8 @@ namespace pinocchio
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorType,
     typename TangentVectorType,
-    typename JacobianMatrixType>
+    typename JacobianMatrixType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int> = 0>
   void dIntegrateTransport(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorType> & q,
@@ -983,7 +995,8 @@ namespace pinocchio
     template<typename, int> class JointCollectionTpl,
     typename ConfigVector1,
     typename ConfigVector2,
-    typename JacobianMatrix>
+    typename JacobianMatrix,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int> = 0>
   void dDifference(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVector1> & q0,
@@ -1102,7 +1115,8 @@ namespace pinocchio
     int Options,
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorIn1,
-    typename ConfigVectorIn2>
+    typename ConfigVectorIn2,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int> = 0>
   Scalar distance(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorIn1> & q0,
@@ -1148,7 +1162,8 @@ namespace pinocchio
     typename Scalar,
     int Options,
     template<typename, int> class JointCollectionTpl,
-    typename ConfigVectorType>
+    typename ConfigVectorType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int> = 0>
   void normalize(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorType> & qout);
@@ -1190,7 +1205,8 @@ namespace pinocchio
     typename Scalar,
     int Options,
     template<typename, int> class JointCollectionTpl,
-    typename ConfigVectorType>
+    typename ConfigVectorType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int> = 0>
   bool isNormalized(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorType> & q,
@@ -1419,7 +1435,8 @@ namespace pinocchio
     int Options,
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorType,
-    typename TangentVectorType>
+    typename TangentVectorType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int> = 0>
   typename PINOCCHIO_EIGEN_PLAIN_TYPE(ConfigVectorType) integrate(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorType> & q,
@@ -1473,7 +1490,8 @@ namespace pinocchio
     int Options,
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorIn1,
-    typename ConfigVectorIn2>
+    typename ConfigVectorIn2,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int> = 0>
   typename PINOCCHIO_EIGEN_PLAIN_TYPE(ConfigVectorIn1) interpolate(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorIn1> & q0,
@@ -1528,7 +1546,8 @@ namespace pinocchio
     int Options,
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorIn1,
-    typename ConfigVectorIn2>
+    typename ConfigVectorIn2,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int> = 0>
   typename PINOCCHIO_EIGEN_PLAIN_TYPE(ConfigVectorIn1) difference(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorIn1> & q0,
@@ -1581,7 +1600,8 @@ namespace pinocchio
     int Options,
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorIn1,
-    typename ConfigVectorIn2>
+    typename ConfigVectorIn2,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int> = 0>
   typename PINOCCHIO_EIGEN_PLAIN_TYPE(ConfigVectorIn1) squaredDistance(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorIn1> & q0,
@@ -1640,7 +1660,8 @@ namespace pinocchio
     int Options,
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorIn1,
-    typename ConfigVectorIn2>
+    typename ConfigVectorIn2,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int> = 0>
   typename PINOCCHIO_EIGEN_PLAIN_TYPE_NO_PARENS(
     (typename ModelTpl<Scalar, Options, JointCollectionTpl>::ConfigVectorType))
     randomConfiguration(
@@ -1706,7 +1727,8 @@ namespace pinocchio
     typename LieGroup_t,
     typename Scalar,
     int Options,
-    template<typename, int> class JointCollectionTpl>
+    template<typename, int> class JointCollectionTpl,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int> = 0>
   typename PINOCCHIO_EIGEN_PLAIN_TYPE_NO_PARENS(
     (typename ModelTpl<Scalar, Options, JointCollectionTpl>::ConfigVectorType))
     randomConfiguration(const ModelTpl<Scalar, Options, JointCollectionTpl> & model);
@@ -1751,7 +1773,8 @@ namespace pinocchio
     typename LieGroup_t,
     typename Scalar,
     int Options,
-    template<typename, int> class JointCollectionTpl>
+    template<typename, int> class JointCollectionTpl,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int> = 0>
   Eigen::Matrix<Scalar, Eigen::Dynamic, 1, Options>
   neutral(const ModelTpl<Scalar, Options, JointCollectionTpl> & model);
 

--- a/include/pinocchio/algorithm/joint-configuration.hpp
+++ b/include/pinocchio/algorithm/joint-configuration.hpp
@@ -29,6 +29,22 @@
 namespace pinocchio
 {
 
+  /// Helpers to use SFINAE for safe candidate selection compare to liegroup-variant-visitors.hxx
+  template<typename T, typename = void>
+  struct is_lie_group_map : std::false_type
+  {
+  };
+
+  // Pointer avoids instantiating operation<void>'s body (no complete type needed),
+  // while still detecting the nested template via SFINAE
+  template<typename T>
+  struct is_lie_group_map<T, std::void_t<typename T::template operation<void> *>> : std::true_type
+  {
+  };
+
+  template<typename T>
+  inline constexpr bool is_lie_group_map_v = is_lie_group_map<T>::value;
+
   /// \name API with return value as argument
   /// \{
 

--- a/include/pinocchio/src/algorithm/joint-configuration.hxx
+++ b/include/pinocchio/src/algorithm/joint-configuration.hxx
@@ -23,7 +23,8 @@ namespace pinocchio
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorType,
     typename TangentVectorType,
-    typename ReturnType>
+    typename ReturnType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int>>
   void integrate(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorType> & q,
@@ -54,7 +55,8 @@ namespace pinocchio
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorIn1,
     typename ConfigVectorIn2,
-    typename ReturnType>
+    typename ReturnType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int>>
   void interpolate(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorIn1> & q0,
@@ -86,7 +88,8 @@ namespace pinocchio
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorIn1,
     typename ConfigVectorIn2,
-    typename ReturnType>
+    typename ReturnType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int>>
   void difference(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorIn1> & q0,
@@ -117,7 +120,8 @@ namespace pinocchio
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorIn1,
     typename ConfigVectorIn2,
-    typename ReturnType>
+    typename ReturnType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int>>
   void squaredDistance(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorIn1> & q0,
@@ -148,7 +152,8 @@ namespace pinocchio
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorIn1,
     typename ConfigVectorIn2,
-    typename ReturnType>
+    typename ReturnType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int>>
   void randomConfiguration(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorIn1> & lowerLimits,
@@ -178,7 +183,8 @@ namespace pinocchio
     typename Scalar,
     int Options,
     template<typename, int> class JointCollectionTpl,
-    typename ReturnType>
+    typename ReturnType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int>>
   void neutral(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ReturnType> & qout)
@@ -202,7 +208,8 @@ namespace pinocchio
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorType,
     typename TangentVectorType,
-    typename JacobianMatrixType>
+    typename JacobianMatrixType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int>>
   void dIntegrate(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorType> & q,
@@ -236,7 +243,8 @@ namespace pinocchio
     int Options,
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorType,
-    typename TangentMapMatrixType>
+    typename TangentMapMatrixType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int>>
   void tangentMap(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorType> & q,
@@ -295,7 +303,8 @@ namespace pinocchio
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorType,
     typename MatrixInType,
-    typename MatrixOutType>
+    typename MatrixOutType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int>>
   void tangentMapProduct(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorType> & q,
@@ -328,7 +337,8 @@ namespace pinocchio
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorType,
     typename MatrixInType,
-    typename MatrixOutType>
+    typename MatrixOutType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int>>
   void tangentMapTransposeProduct(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorType> & q,
@@ -364,7 +374,8 @@ namespace pinocchio
     typename ConfigVectorType,
     typename TangentVectorType,
     typename JacobianMatrixType1,
-    typename JacobianMatrixType2>
+    typename JacobianMatrixType2,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int>>
   void dIntegrateTransport(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorType> & q,
@@ -403,7 +414,8 @@ namespace pinocchio
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorType,
     typename TangentVectorType,
-    typename JacobianMatrixType>
+    typename JacobianMatrixType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int>>
   void dIntegrateTransport(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorType> & q,
@@ -435,7 +447,8 @@ namespace pinocchio
     template<typename, int> class JointCollectionTpl,
     typename ConfigVector1,
     typename ConfigVector2,
-    typename JacobianMatrix>
+    typename JacobianMatrix,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int>>
   void dDifference(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVector1> & q0,
@@ -496,7 +509,8 @@ namespace pinocchio
     int Options,
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorIn1,
-    typename ConfigVectorIn2>
+    typename ConfigVectorIn2,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int>>
   Scalar distance(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorIn1> & q0,
@@ -513,7 +527,8 @@ namespace pinocchio
     typename Scalar,
     int Options,
     template<typename, int> class JointCollectionTpl,
-    typename ConfigVectorType>
+    typename ConfigVectorType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int>>
   void normalize(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorType> & qout)
@@ -535,7 +550,8 @@ namespace pinocchio
     typename Scalar,
     int Options,
     template<typename, int> class JointCollectionTpl,
-    typename ConfigVectorIn>
+    typename ConfigVectorIn,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int>>
   bool isNormalized(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorIn> & q,
@@ -664,7 +680,8 @@ namespace pinocchio
     int Options,
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorType,
-    typename TangentVectorType>
+    typename TangentVectorType,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int>>
   typename PINOCCHIO_EIGEN_PLAIN_TYPE(ConfigVectorType) integrate(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorType> & q,
@@ -684,7 +701,8 @@ namespace pinocchio
     int Options,
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorIn1,
-    typename ConfigVectorIn2>
+    typename ConfigVectorIn2,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int>>
   typename PINOCCHIO_EIGEN_PLAIN_TYPE(ConfigVectorIn1) interpolate(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorIn1> & q0,
@@ -705,7 +723,8 @@ namespace pinocchio
     int Options,
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorIn1,
-    typename ConfigVectorIn2>
+    typename ConfigVectorIn2,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int>>
   typename PINOCCHIO_EIGEN_PLAIN_TYPE(ConfigVectorIn1) difference(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorIn1> & q0,
@@ -725,7 +744,8 @@ namespace pinocchio
     int Options,
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorIn1,
-    typename ConfigVectorIn2>
+    typename ConfigVectorIn2,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int>>
   typename PINOCCHIO_EIGEN_PLAIN_TYPE(ConfigVectorIn1) squaredDistance(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorIn1> & q0,
@@ -745,7 +765,8 @@ namespace pinocchio
     int Options,
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorIn1,
-    typename ConfigVectorIn2>
+    typename ConfigVectorIn2,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int>>
   typename PINOCCHIO_EIGEN_PLAIN_TYPE_NO_PARENS(
     (typename ModelTpl<Scalar, Options, JointCollectionTpl>::ConfigVectorType))
     randomConfiguration(
@@ -766,7 +787,8 @@ namespace pinocchio
     typename LieGroup_t,
     typename Scalar,
     int Options,
-    template<typename, int> class JointCollectionTpl>
+    template<typename, int> class JointCollectionTpl,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int>>
   typename PINOCCHIO_EIGEN_PLAIN_TYPE_NO_PARENS(
     (typename ModelTpl<Scalar, Options, JointCollectionTpl>::ConfigVectorType))
     randomConfiguration(const ModelTpl<Scalar, Options, JointCollectionTpl> & model)
@@ -782,7 +804,8 @@ namespace pinocchio
     typename LieGroup_t,
     typename Scalar,
     int Options,
-    template<typename, int> class JointCollectionTpl>
+    template<typename, int> class JointCollectionTpl,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int>>
   Eigen::Matrix<Scalar, Eigen::Dynamic, 1, Options>
   neutral(const ModelTpl<Scalar, Options, JointCollectionTpl> & model)
   {

--- a/include/pinocchio/src/algorithm/joint-configuration.hxx
+++ b/include/pinocchio/src/algorithm/joint-configuration.hxx
@@ -565,7 +565,8 @@ namespace pinocchio
     int Options,
     template<typename, int> class JointCollectionTpl,
     typename ConfigVectorIn1,
-    typename ConfigVectorIn2>
+    typename ConfigVectorIn2,
+    std::enable_if_t<is_lie_group_map_v<LieGroup_t>, int>>
   bool isSameConfiguration(
     const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
     const Eigen::MatrixBase<ConfigVectorIn1> & q1,

--- a/include/pinocchio/src/multibody/liegroup/liegroup-variant-visitors.hxx
+++ b/include/pinocchio/src/multibody/liegroup/liegroup-variant-visitors.hxx
@@ -102,7 +102,11 @@ namespace pinocchio
     const typename Config_t::Scalar & prec =
       Eigen::NumTraits<typename Config_t::Scalar>::dummy_precision());
 
-  template<typename LieGroupCollection, class ConfigL_t, class ConfigR_t>
+  template<
+    typename LieGroupCollection,
+    class ConfigL_t,
+    class ConfigR_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int> = 0>
   inline bool isSameConfiguration(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<ConfigL_t> & q0,
@@ -534,7 +538,11 @@ namespace pinocchio
     }
   };
 
-  template<typename LieGroupCollection, class ConfigL_t, class ConfigR_t>
+  template<
+    typename LieGroupCollection,
+    class ConfigL_t,
+    class ConfigR_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int>>
   inline bool isSameConfiguration(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<ConfigL_t> & q0,

--- a/include/pinocchio/src/multibody/liegroup/liegroup-variant-visitors.hxx
+++ b/include/pinocchio/src/multibody/liegroup/liegroup-variant-visitors.hxx
@@ -67,7 +67,9 @@ namespace pinocchio
    *
    * @return     The Lie group neutral element
    */
-  template<typename LieGroupCollection>
+  template<
+    typename LieGroupCollection,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int> = 0>
   inline Eigen::
     Matrix<typename LieGroupCollection::Scalar, Eigen::Dynamic, 1, LieGroupCollection::Options>
     neutral(const LieGroupGenericTpl<LieGroupCollection> & lg);
@@ -80,7 +82,12 @@ namespace pinocchio
    * @param[in]  v   the tangent velocity.
    *
    */
-  template<typename LieGroupCollection, class ConfigIn_t, class Tangent_t, class ConfigOut_t>
+  template<
+    typename LieGroupCollection,
+    class ConfigIn_t,
+    class Tangent_t,
+    class ConfigOut_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int> = 0>
   inline void integrate(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<ConfigIn_t> & q,
@@ -91,11 +98,17 @@ namespace pinocchio
   inline void random(
     const LieGroupGenericTpl<LieGroupCollection> & lg, const Eigen::MatrixBase<Config_t> & qout);
 
-  template<typename LieGroupCollection, class Config_t>
+  template<
+    typename LieGroupCollection,
+    class Config_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int> = 0>
   inline void normalize(
     const LieGroupGenericTpl<LieGroupCollection> & lg, const Eigen::MatrixBase<Config_t> & qout);
 
-  template<typename LieGroupCollection, class Config_t>
+  template<
+    typename LieGroupCollection,
+    class Config_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int> = 0>
   inline bool isNormalized(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<Config_t> & qin,
@@ -113,13 +126,21 @@ namespace pinocchio
     const Eigen::MatrixBase<ConfigR_t> & q1,
     const typename ConfigL_t::Scalar & prec);
 
-  template<typename LieGroupCollection, class ConfigL_t, class ConfigR_t>
+  template<
+    typename LieGroupCollection,
+    class ConfigL_t,
+    class ConfigR_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int> = 0>
   inline typename ConfigL_t::Scalar squaredDistance(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<ConfigL_t> & q0,
     const Eigen::MatrixBase<ConfigR_t> & q1);
 
-  template<typename LieGroupCollection, class ConfigL_t, class ConfigR_t>
+  template<
+    typename LieGroupCollection,
+    class ConfigL_t,
+    class ConfigR_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int> = 0>
   inline typename ConfigL_t::Scalar distance(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<ConfigL_t> & q0,
@@ -128,21 +149,36 @@ namespace pinocchio
     return std::sqrt(squaredDistance(lg, q0, q1));
   }
 
-  template<typename LieGroupCollection, class ConfigL_t, class ConfigR_t, class Tangent_t>
+  template<
+    typename LieGroupCollection,
+    class ConfigL_t,
+    class ConfigR_t,
+    class Tangent_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int> = 0>
   inline void difference(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<ConfigL_t> & q0,
     const Eigen::MatrixBase<ConfigR_t> & q1,
     const Eigen::MatrixBase<Tangent_t> & v);
 
-  template<typename LieGroupCollection, class ConfigL_t, class ConfigR_t, class ConfigOut_t>
+  template<
+    typename LieGroupCollection,
+    class ConfigL_t,
+    class ConfigR_t,
+    class ConfigOut_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int> = 0>
   inline void randomConfiguration(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<ConfigL_t> & q0,
     const Eigen::MatrixBase<ConfigR_t> & q1,
     const Eigen::MatrixBase<ConfigOut_t> & qout);
 
-  template<typename LieGroupCollection, class ConfigL_t, class ConfigR_t, class ConfigOut_t>
+  template<
+    typename LieGroupCollection,
+    class ConfigL_t,
+    class ConfigR_t,
+    class ConfigOut_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int> = 0>
   inline void interpolate(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<ConfigL_t> & q0,
@@ -150,7 +186,12 @@ namespace pinocchio
     const typename ConfigL_t::Scalar & u,
     const Eigen::MatrixBase<ConfigOut_t> & qout);
 
-  template<typename LieGroupCollection, class Config_t, class Tangent_t, class JacobianOut_t>
+  template<
+    typename LieGroupCollection,
+    class Config_t,
+    class Tangent_t,
+    class JacobianOut_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int> = 0>
   void dIntegrate(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<Config_t> & q,
@@ -164,7 +205,8 @@ namespace pinocchio
     class Config_t,
     class Tangent_t,
     class JacobianIn_t,
-    class JacobianOut_t>
+    class JacobianOut_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int> = 0>
   void dIntegrate(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<Config_t> & q,
@@ -180,7 +222,8 @@ namespace pinocchio
     class Config_t,
     class Tangent_t,
     class JacobianIn_t,
-    class JacobianOut_t>
+    class JacobianOut_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int> = 0>
   void dIntegrate(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<Config_t> & q,
@@ -191,7 +234,12 @@ namespace pinocchio
     const ArgumentPosition arg,
     const AssignmentOperatorType op = SETTO);
 
-  template<typename LieGroupCollection, class ConfigL_t, class ConfigR_t, class JacobianOut_t>
+  template<
+    typename LieGroupCollection,
+    class ConfigL_t,
+    class ConfigR_t,
+    class JacobianOut_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int> = 0>
   void dDifference(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<ConfigL_t> & q0,
@@ -204,7 +252,8 @@ namespace pinocchio
     class ConfigL_t,
     class ConfigR_t,
     class JacobianIn_t,
-    class JacobianOut_t>
+    class JacobianOut_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int> = 0>
   void dDifference(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<ConfigL_t> & q0,
@@ -219,7 +268,8 @@ namespace pinocchio
     class ConfigL_t,
     class ConfigR_t,
     class JacobianIn_t,
-    class JacobianOut_t>
+    class JacobianOut_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int> = 0>
   void dDifference(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<ConfigL_t> & q0,
@@ -229,14 +279,23 @@ namespace pinocchio
     const Eigen::MatrixBase<JacobianOut_t> & Jout,
     const ArgumentPosition arg);
 
-  template<typename LieGroupCollection, class Config_t, class TangentMap_t>
+  template<
+    typename LieGroupCollection,
+    class Config_t,
+    class TangentMap_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int> = 0>
   void tangentMap(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<Config_t> & q,
     const Eigen::MatrixBase<TangentMap_t> & TM,
     const AssignmentOperatorType op);
 
-  template<typename LieGroupCollection, class Config_t, class MatrixIn_t, class MatrixOut_t>
+  template<
+    typename LieGroupCollection,
+    class Config_t,
+    class MatrixIn_t,
+    class MatrixOut_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int> = 0>
   void tangentMapProduct(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<Config_t> & q,
@@ -244,7 +303,12 @@ namespace pinocchio
     const Eigen::MatrixBase<MatrixOut_t> & Mout,
     const AssignmentOperatorType op);
 
-  template<typename LieGroupCollection, class Config_t, class MatrixIn_t, class MatrixOut_t>
+  template<
+    typename LieGroupCollection,
+    class Config_t,
+    class MatrixIn_t,
+    class MatrixOut_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int> = 0>
   void tangentMapTransposeProduct(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<Config_t> & q,
@@ -257,7 +321,8 @@ namespace pinocchio
     class Config_t,
     class Tangent_t,
     class JacobianIn_t,
-    class JacobianOut_t>
+    class JacobianOut_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int> = 0>
   void dIntegrateTransport(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<Config_t> & q,
@@ -266,7 +331,12 @@ namespace pinocchio
     const Eigen::MatrixBase<JacobianOut_t> & J_out,
     const ArgumentPosition arg);
 
-  template<typename LieGroupCollection, class Config_t, class Tangent_t, class JacobianOut_t>
+  template<
+    typename LieGroupCollection,
+    class Config_t,
+    class Tangent_t,
+    class JacobianOut_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int> = 0>
   void dIntegrateTransport(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<Config_t> & q,
@@ -430,7 +500,9 @@ namespace pinocchio
     }
   };
 
-  template<typename LieGroupCollection>
+  template<
+    typename LieGroupCollection,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int>>
   inline Eigen::
     Matrix<typename LieGroupCollection::Scalar, Eigen::Dynamic, 1, LieGroupCollection::Options>
     neutral(const LieGroupGenericTpl<LieGroupCollection> & lg)
@@ -468,7 +540,10 @@ namespace pinocchio
     Operation::run(lg, typename Operation::ArgsType(qout));
   }
 
-  template<typename LieGroupCollection, class Config_t>
+  template<
+    typename LieGroupCollection,
+    class Config_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int>>
   inline void normalize(
     const LieGroupGenericTpl<LieGroupCollection> & lg, const Eigen::MatrixBase<Config_t> & qout)
   {
@@ -500,7 +575,10 @@ namespace pinocchio
     }
   };
 
-  template<typename LieGroupCollection, class Config_t>
+  template<
+    typename LieGroupCollection,
+    class Config_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int>>
   inline bool isNormalized(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<Config_t> & qin,
@@ -584,7 +662,11 @@ namespace pinocchio
   // PINOCCHIO_LG_VISITOR(Distance, distance);
   PINOCCHIO_LG_VISITOR(SquaredDistance, squaredDistance);
 
-  template<typename LieGroupCollection, class ConfigL_t, class ConfigR_t>
+  template<
+    typename LieGroupCollection,
+    class ConfigL_t,
+    class ConfigR_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int>>
   inline typename ConfigL_t::Scalar squaredDistance(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<ConfigL_t> & q0,
@@ -628,7 +710,12 @@ namespace pinocchio
   PINOCCHIO_LG_VISITOR(Difference, difference);
   PINOCCHIO_LG_VISITOR(RandomConfiguration, randomConfiguration);
 
-  template<typename LieGroupCollection, class ConfigIn_t, class Tangent_t, class ConfigOut_t>
+  template<
+    typename LieGroupCollection,
+    class ConfigIn_t,
+    class Tangent_t,
+    class ConfigOut_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int>>
   inline void integrate(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<ConfigIn_t> & q,
@@ -643,7 +730,12 @@ namespace pinocchio
     Operation::run(lg, typename Operation::ArgsType(q, v, qout));
   }
 
-  template<typename LieGroupCollection, class ConfigL_t, class ConfigR_t, class Tangent_t>
+  template<
+    typename LieGroupCollection,
+    class ConfigL_t,
+    class ConfigR_t,
+    class Tangent_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int>>
   inline void difference(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<ConfigL_t> & q0,
@@ -658,7 +750,12 @@ namespace pinocchio
     Operation::run(lg, typename Operation::ArgsType(q0, q1, v));
   }
 
-  template<typename LieGroupCollection, class ConfigL_t, class ConfigR_t, class ConfigOut_t>
+  template<
+    typename LieGroupCollection,
+    class ConfigL_t,
+    class ConfigR_t,
+    class ConfigOut_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int>>
   inline void randomConfiguration(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<ConfigL_t> & q0,
@@ -699,7 +796,12 @@ namespace pinocchio
     }
   };
 
-  template<typename LieGroupCollection, class ConfigL_t, class ConfigR_t, class ConfigOut_t>
+  template<
+    typename LieGroupCollection,
+    class ConfigL_t,
+    class ConfigR_t,
+    class ConfigOut_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int>>
   inline void interpolate(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<ConfigL_t> & q0,
@@ -745,7 +847,12 @@ namespace pinocchio
   PINOCCHIO_LG_VISITOR(DIntegrate, dIntegrate, 1);
   PINOCCHIO_LG_VISITOR(DDifference, dDifference, 0);
 
-  template<typename LieGroupCollection, class Config_t, class Tangent_t, class JacobianOut_t>
+  template<
+    typename LieGroupCollection,
+    class Config_t,
+    class Tangent_t,
+    class JacobianOut_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int>>
   void dIntegrate(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<Config_t> & q,
@@ -762,7 +869,12 @@ namespace pinocchio
     Operation::run(lg, typename Operation::ArgsType(q, v, J, arg, op));
   }
 
-  template<typename LieGroupCollection, class ConfigL_t, class ConfigR_t, class JacobianOut_t>
+  template<
+    typename LieGroupCollection,
+    class ConfigL_t,
+    class ConfigR_t,
+    class JacobianOut_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int>>
   void dDifference(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<ConfigL_t> & q0,
@@ -833,7 +945,8 @@ namespace pinocchio
     class Config_t,
     class Tangent_t,
     class JacobianIn_t,
-    class JacobianOut_t>
+    class JacobianOut_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int>>
   void dIntegrate(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<Config_t> & q,
@@ -862,7 +975,8 @@ namespace pinocchio
     class Config_t,
     class Tangent_t,
     class JacobianIn_t,
-    class JacobianOut_t>
+    class JacobianOut_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int>>
   void dIntegrate(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<Config_t> & q,
@@ -1032,7 +1146,8 @@ namespace pinocchio
     class Config_t,
     class Tangent_t,
     class JacobianIn_t,
-    class JacobianOut_t>
+    class JacobianOut_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int>>
   void dIntegrateTransport(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<Config_t> & q,
@@ -1051,7 +1166,12 @@ namespace pinocchio
     Operation::run(lg, typename Operation::ArgsType(q, v, J_in, J_out, arg));
   }
 
-  template<typename LieGroupCollection, class Config_t, class Tangent_t, class JacobianOut_t>
+  template<
+    typename LieGroupCollection,
+    class Config_t,
+    class Tangent_t,
+    class JacobianOut_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int>>
   void dIntegrateTransport(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<Config_t> & q,
@@ -1094,7 +1214,11 @@ namespace pinocchio
     }
   };
 
-  template<typename LieGroupCollection, class Config_t, class TangentMap_t>
+  template<
+    typename LieGroupCollection,
+    class Config_t,
+    class TangentMap_t,
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int>>
   void tangentMap(
     const LieGroupGenericTpl<LieGroupCollection> & lg,
     const Eigen::MatrixBase<Config_t> & q,
@@ -1132,7 +1256,9 @@ namespace pinocchio
       lg._method(q, Min, Mout, op);                                                                \
     }                                                                                              \
   };                                                                                               \
-  template<typename LieGroupCollection, class Config_t, class MatrixIn_t, class MatrixOut_t>       \
+  template<                                                                                        \
+    typename LieGroupCollection, class Config_t, class MatrixIn_t, class MatrixOut_t,              \
+    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int>>                          \
   void _method(                                                                                    \
     const LieGroupGenericTpl<LieGroupCollection> & lg, const Eigen::MatrixBase<Config_t> & q,      \
     const Eigen::MatrixBase<MatrixIn_t> & Min, const Eigen::MatrixBase<MatrixOut_t> & Mout,        \

--- a/include/pinocchio/src/multibody/liegroup/liegroup-variant-visitors.hxx
+++ b/include/pinocchio/src/multibody/liegroup/liegroup-variant-visitors.hxx
@@ -249,38 +249,6 @@ namespace pinocchio
 
   template<
     typename LieGroupCollection,
-    class ConfigL_t,
-    class ConfigR_t,
-    class JacobianIn_t,
-    class JacobianOut_t,
-    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int> = 0>
-  void dDifference(
-    const LieGroupGenericTpl<LieGroupCollection> & lg,
-    const Eigen::MatrixBase<ConfigL_t> & q0,
-    const Eigen::MatrixBase<ConfigR_t> & q1,
-    const Eigen::MatrixBase<JacobianIn_t> & Jin,
-    int self,
-    const Eigen::MatrixBase<JacobianOut_t> & Jout,
-    const ArgumentPosition arg);
-
-  template<
-    typename LieGroupCollection,
-    class ConfigL_t,
-    class ConfigR_t,
-    class JacobianIn_t,
-    class JacobianOut_t,
-    std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int> = 0>
-  void dDifference(
-    const LieGroupGenericTpl<LieGroupCollection> & lg,
-    const Eigen::MatrixBase<ConfigL_t> & q0,
-    const Eigen::MatrixBase<ConfigR_t> & q1,
-    int self,
-    const Eigen::MatrixBase<JacobianIn_t> & Jin,
-    const Eigen::MatrixBase<JacobianOut_t> & Jout,
-    const ArgumentPosition arg);
-
-  template<
-    typename LieGroupCollection,
     class Config_t,
     class TangentMap_t,
     std::enable_if_t<is_lie_group_collection_v<LieGroupCollection>, int> = 0>

--- a/include/pinocchio/src/multibody/liegroup/liegroup-variant-visitors.hxx
+++ b/include/pinocchio/src/multibody/liegroup/liegroup-variant-visitors.hxx
@@ -14,6 +14,20 @@
 namespace pinocchio
 {
 
+  /// Helpers to use SFINAE for safe candidate selection compare to joint-configuration.hpp
+  template<typename T, typename = void>
+  struct is_lie_group_collection : std::false_type
+  {
+  };
+
+  template<typename T>
+  struct is_lie_group_collection<T, std::void_t<typename T::LieGroupVariant>> : std::true_type
+  {
+  };
+
+  template<typename T>
+  inline constexpr bool is_lie_group_collection_v = is_lie_group_collection<T>::value;
+
   /**
    * @brief      Visit a LieGroupVariant to get the dimension of
    *             the Lie group configuration space


### PR DESCRIPTION
## Description
Create SFINAE based helpers template structs to create templated `constexpr bool` : `is_liegroup_map_v` and `is_liegroup_collection_v` 

Then use a classic SFINAE idiom `enable_if_t<is_liegroup_XXX_v<T>, int> = 0` as additional muted argument for the functions that use template arguments `LieGroupMap` or `LieGroupCollection`.

If `is_liegroup_XXX_v` is true `enable_if_t` is int defaulting to 0, so it is the default value that is called and the candidate passe the template resolution phase.

If `is_liegroup_XXX_v` is false, `enable_if_t` will raise an error in immediate context so thanks to SFINAE the candidate will just be discard.

From point of view of users, it does not change a thing. Overall, it just robustify the overload selection to avoid nameclash between functions in `joint-configuration.hpp` and `liegroup-variant-visitor.hxx`.

------------

Under the hood `is_liegroup_XXX_v<T>` only return the value `is_liegroup_XXX<T>` which default to false type and specialized to the true type when T got some well chosen member.

Again for this specialization it use SFINAE as:
```
template<typename T, class = void>
is_liegroup_XXX: falsetype;

template<typename T>
is_liegroup_XXX<T, void_t<T::TYPETOEXIST>>: truetype;
```

Thus, calling `is_liegroup_XXX<T>` become `is_liegroup_XXX<T, void>` and a first candidate is the default candidate (false type). Then when checking the candidate overload, if `T` has `TYPETOEXIST`, `void_t<T::TYPETOEXIST>`is void so the candidate have the good template signature and superseed the default one and we have the true type. If `T` has not `TYPETOEXIST`,  `void_t<T::TYPETOEXIST>` raise an error in immediate context and SFINAE just discard the candidate.

NB: because `LieGroupMap` posses only template and not type, the trick is to get the pointer-type to the instanciation of a template on a dummy type (void) which exist only if the template exist without the need of instantiating the concrete type, hence: `std::void_t<typename T::template operation<void> *>`

## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the doxygen documentation
- [x] I have added tests that prove my fix or feature works
- [x] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [x] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
