### PR TITLE
Topic/delassus clean pin4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add `pinochio/container/eigen-storage.hpp`: Introduce `EigenStorageTpl`
 
 ### Changed
+- Clean delassus API: DelassusOperatorBase define the main delassus API and each method calls `derived().[name-of-method]Impl`
 - Fix potential bug in joint limit due to uninitialized field
 - Add missing constructor for joint friction
 - Solvers can be safely copied (result and workspace copy constructor/operator are now safely handled)

--- a/include/pinocchio/bindings/python/algorithm/constraint-cholesky.hpp
+++ b/include/pinocchio/bindings/python/algorithm/constraint-cholesky.hpp
@@ -319,8 +319,8 @@ namespace pinocchio
             .def(
               "matrix",
               static_cast<SparseMatrix (DelassusOperatorSparse::*)(bool) const>(
-                &DelassusOperatorSparse::matrix),
-              (bp::arg("self"), bp::arg("enforce_symmetry") = false),
+                &DelassusOperatorSparse::sparseMatrix),
+              (bp::arg("self"), bp::arg("with_damping") = true),
               "Returns the Delassus expression as a sparse matrix.");
 #endif // PINOCCHIO_PYTHON_SKIP_CASADI_UNSUPPORTED
         }

--- a/include/pinocchio/bindings/python/algorithm/delassus-operator.hpp
+++ b/include/pinocchio/bindings/python/algorithm/delassus-operator.hpp
@@ -34,37 +34,37 @@ namespace pinocchio
     {
       typedef DelassusOperator Self;
       typedef typename DelassusOperator::Scalar Scalar;
-      typedef context::MatrixXs Matrix;
-      typedef typename DelassusOperator::Vector Vector;
+      typedef context::MatrixXs MatrixXs;
+      typedef context::VectorXs VectorXs;
       typedef typename traits<DelassusOperator>::getDampingReturnType getDampingReturnType;
 
       template<class PyClass>
       void visit(PyClass & cl) const
       {
-        cl.def(bp::self * bp::other<Matrix>())
+        cl.def(bp::self * bp::other<MatrixXs>())
           .def(
             "__matmul__",
-            +[](const DelassusOperator & self, const Matrix & other) -> Matrix {
-              return Matrix(self * other);
+            +[](const DelassusOperator & self, const MatrixXs & other) -> MatrixXs {
+              return MatrixXs(self * other);
             },
             bp::args("self", "other"),
             "Matrix multiplication between self and another matrix. Returns the result of Delassus "
             "* matrix.")
 
           .def(
-            "solve", &DelassusOperator::template solve<Matrix>, bp::args("self", "mat"),
+            "solve", &DelassusOperator::template solve<MatrixXs>, bp::args("self", "mat"),
             "Returns the solution x of Delassus * x = mat using the current decomposition of the "
             "Delassus matrix.")
 
           .def(
             "updateCompliance",
-            (void (DelassusOperator::*)(const Scalar &))&DelassusOperator::updateCompliance,
+            (void (DelassusOperator::*)(const Scalar))&DelassusOperator::updateCompliance,
             bp::args("self", "mu"),
             "Add a compliance term to the diagonal of the Delassus matrix. The compliance term "
             "should be "
             "positive.")
           .def(
-            "updateCompliance", &DelassusOperator::template updateCompliance<Vector>,
+            "updateCompliance", &DelassusOperator::template updateCompliance<VectorXs>,
             bp::args("self", "mus"),
             "Add a compliance term to the diagonal of the Delassus matrix. The compliance terms "
             "should "
@@ -72,20 +72,18 @@ namespace pinocchio
 
           .def(
             "getCompliance",
-            +[](const DelassusOperator & self) -> context::VectorXs {
-              return self.getCompliance();
-            },
+            +[](const DelassusOperator & self) -> VectorXs { return self.getCompliance(); },
             bp::arg("self"),
             "Returns the value of the compliance terms contained in the Delassus operator")
 
           .def(
             "updateDamping",
-            (void (DelassusOperator::*)(const Scalar &))&DelassusOperator::updateDamping,
+            (void (DelassusOperator::*)(const Scalar))&DelassusOperator::updateDamping,
             bp::args("self", "mu"),
             "Add a damping term to the diagonal of the Delassus matrix. The damping term should be "
             "positive.")
           .def(
-            "updateDamping", &DelassusOperator::template updateDamping<Vector>,
+            "updateDamping", &DelassusOperator::template updateDamping<VectorXs>,
             bp::args("self", "mus"),
             "Add a damping term to the diagonal of the Delassus matrix. The damping terms should "
             "be all positive.")
@@ -110,7 +108,8 @@ namespace pinocchio
         {
           cl.def(
             "matrix",
-            static_cast<Matrix (DelassusOperator::*)(bool, bool) const>(&DelassusOperator::matrix),
+            static_cast<MatrixXs (DelassusOperator::*)(bool, bool) const>(
+              &DelassusOperator::matrix),
             (bp::arg("self"), bp::arg("enforce_symmetry") = false, bp::arg("with_damping") = true),
             "Returns the Delassus expression as a dense matrix.");
         }

--- a/include/pinocchio/src/algorithm/constraint-cholesky-decl.hxx
+++ b/include/pinocchio/src/algorithm/constraint-cholesky-decl.hxx
@@ -69,6 +69,7 @@ namespace pinocchio
     typedef EigenStorageTpl<Matrix> EigenStorageMatrix;
     typedef EigenStorageTpl<RowMatrix> EigenStorageRowMatrix;
     typedef BlockDiagonalMatrixTpl<Scalar, Options> BlockDiagonalMatrix;
+    typedef BlockDiagonalMatrix DampingType;
 
     typedef Eigen::Matrix<Eigen::Index, Eigen::Dynamic, 1, Options> EigenIndexVector;
     typedef typename std::vector<EigenIndexVector> VectorOfEigenIndexVector;

--- a/include/pinocchio/src/algorithm/delassus-operator-base.hxx
+++ b/include/pinocchio/src/algorithm/delassus-operator-base.hxx
@@ -18,7 +18,7 @@ namespace pinocchio
   struct traits<DelassusOperatorApplyOnTheRightReturnType<DelassusOperatorDerived, MatrixDerived>>
   {
     typedef typename traits<DelassusOperatorDerived>::Scalar Scalar;
-    typedef typename traits<DelassusOperatorDerived>::Matrix Matrix;
+    typedef typename traits<DelassusOperatorDerived>::MatrixXs Matrix;
   };
 
   template<typename DelassusOperatorDerived, typename MatrixDerived>
@@ -36,6 +36,8 @@ namespace Eigen
   namespace internal
   {
 
+    // Required by Eigen::ReturnByValue: provides the concrete ReturnType that the lazy expression
+    // evaluates into, and the expression Flags.
     template<typename DelassusOperatorDerived, typename MatrixDerived>
     struct traits<
       pinocchio::DelassusOperatorApplyOnTheRightReturnType<DelassusOperatorDerived, MatrixDerived>>
@@ -44,6 +46,8 @@ namespace Eigen
       static constexpr int Flags = 0;
     };
 
+    // Dispatched by Eigen when assigning a lazy delassus * x expression to a dense matrix.
+    // Resizes the destination if needed, then triggers evaluation via evalTo -> applyOnTheRight.
     template<
       typename DstXprType,
       typename DelassusOperatorDerived,
@@ -117,93 +121,109 @@ namespace pinocchio
     const MatrixDerived & m_rhs;
   };
 
-  template<typename DelassusOperatorDerived>
+  /// \brief Unsafe version of DelassusOperatorBase<Derived>.
+  /// This struct provides unsafe access to the internal data of the Delassus operator, such
+  /// as the numerical damping.
+  /// This is meant to be used by Pinocchio's algorithms or expert users who know what they are
+  /// doing.
+  /// This base access struct provides the common interface and some common functionalities for all
+  /// Unsafe<DelassusOperatorBase> specializations.
+  template<typename Derived>
+  struct Unsafe<DelassusOperatorBase<Derived>>
+  {
+    typedef Derived SafeDerived;
+    typedef typename traits<Derived>::DampingType DampingType;
+
+    /// \brief Constructor from a reference to the safe base.
+    Unsafe(SafeDerived & self)
+    : self(self)
+    {
+    }
+
+    /// \brief Cast to unsafe Derived.
+    Unsafe<Derived> unsafe_derived()
+    {
+      return Unsafe<Derived>(self);
+    }
+
+    /// \brief Signal the delassus that updateDecomposition() should be called.
+    /// This is typically called after damping or compliance has been updated
+    /// so updateSumComplianceDamping is called internally.
+    void makeDirty()
+    {
+      unsafe_derived().makeDirtyImpl();
+    }
+
+    /// \brief Getter to the block diagonal damping.
+    DampingType & damping()
+    {
+      return unsafe_derived().dampingImpl();
+    }
+
+    SafeDerived & self;
+  };
+
+  /// \brief CRTP base class for Delassus operators.
+  /// The Delassus operator is the square linear operator that maps the constraint forces to the
+  /// constraint accelerations. We often denote G and its dense representation is J^T Minv J, where
+  /// J is the constraints jacobian, Minv is the inverse of the mass matrix of the system. The
+  /// Delassus operator is used in the context of constraint-based dynamics algorithms, such as the
+  /// non-smooth contact dynamics algorithms implemented in Pinocchio. The Delassus operator may
+  /// also include numerical damping (for numerical solvers) and physical compliance (for soft
+  /// constraints). This base class provides the common interface and some common functionalities
+  /// for all Delassus operator implementations.
+  template<typename Derived>
   struct DelassusOperatorBase
   {
-    typedef typename traits<DelassusOperatorDerived>::Scalar Scalar;
-    typedef typename traits<DelassusOperatorDerived>::Vector Vector;
-    typedef typename traits<DelassusOperatorDerived>::getDampingReturnType getDampingReturnType;
-    typedef PowerIterationAlgoTpl<Vector> PowerIterationAlgo;
+    typedef typename traits<Derived>::Scalar Scalar;
+    typedef typename traits<Derived>::VectorXs VectorXs;
+    typedef typename traits<Derived>::MatrixXs MatrixXs;
+    typedef typename traits<Derived>::getDampingReturnType getDampingReturnType;
+    typedef typename traits<Derived>::getComplianceReturnType getComplianceReturnType;
 
-    DelassusOperatorDerived & derived()
+    /// \brief Cast to Derived.
+    Derived & derived()
     {
-      return static_cast<DelassusOperatorDerived &>(*this);
+      return static_cast<Derived &>(*this);
     }
-    const DelassusOperatorDerived & derived() const
+    const Derived & derived() const
     {
-      return static_cast<const DelassusOperatorDerived &>(*this);
+      return static_cast<const Derived &>(*this);
     }
 
+    /// \brief Cast to Unsafe<Derived>.
+    Unsafe<DelassusOperatorBase<Derived>> unsafe()
+    {
+      return derived().unsafeImpl();
+    }
+    friend struct Unsafe<DelassusOperatorBase<Derived>>;
+
+  protected:
+    /// \brief Default constructor.
+    /// Protected so that DelassusOperatorBase cannot be constructed.
     DelassusOperatorBase()
     {
     }
 
-    template<typename VectorLike>
-    void updateCompliance(const Eigen::MatrixBase<VectorLike> & compliance)
-    {
-      derived().updateCompliance(compliance.derived());
-    }
-
-    void updateCompliance(const Scalar compliance)
-    {
-      derived().updateCompliance(Vector::Constant(size(), compliance));
-    }
-
-    template<typename VectorLike>
-    void updateDamping(const Eigen::MatrixBase<VectorLike> & vec)
-    {
-      derived().updateDamping(vec.derived());
-    }
-
-    void updateDamping(const Scalar mu)
-    {
-      derived().updateDamping(mu);
-    }
-
-    /// \brief Update the decomposition, following for instance, a call to updateDamping or
-    /// updateCompliance
-    void updateDecomposition()
-    {
-      derived().updateDecomposition();
-    }
-
-    /// \returns true if the Delassus is not valid, for instance, after a call to updateDamping or
-    /// updateCompliance
-    bool isDirty() const
-    {
-      return derived().isDirty();
-    }
-
-    template<typename MatrixLike>
-    void solveInPlace(const Eigen::MatrixBase<MatrixLike> & mat) const
-    {
-      derived().solveInPlace(mat.const_cast_derived());
-    }
-
-    template<typename MatrixLike>
-    typename PINOCCHIO_EIGEN_PLAIN_TYPE(MatrixLike)
-      solve(const Eigen::MatrixBase<MatrixLike> & mat) const
-    {
-      return derived().solve(mat);
-    }
-
-    template<typename MatrixDerivedIn, typename MatrixDerivedOut>
-    void solve(
-      const Eigen::MatrixBase<MatrixDerivedIn> & x,
-      const Eigen::MatrixBase<MatrixDerivedOut> & res) const
-    {
-      derived().solve(x.derived(), res.const_cast_derived());
-    }
-
+  public:
+    /// \brief Stores the product delassus * x in res.
+    ///
+    /// \param[in] x The matrix to multiply on the right of the Delassus operator.
+    /// \param[out] res The result of the product delassus * x.
+    /// \param[in] with_damping If true, the numerical damping is taken into account.
     template<typename MatrixIn, typename MatrixOut>
     void applyOnTheRight(
       const Eigen::MatrixBase<MatrixIn> & x,
       const Eigen::MatrixBase<MatrixOut> & res,
       bool with_damping = true) const
     {
-      derived().applyOnTheRight(x.derived(), res.const_cast_derived(), with_damping);
+      derived().applyOnTheRightImpl(x.derived(), res.const_cast_derived(), with_damping);
     }
 
+    /// \brief Lazy multiplication operator, returning an Eigen expression representing the product
+    /// of the Delassus operator with a matrix on the right.
+    /// \warning Numerical damping is taken into account. Use applyOnTheRight if you want to control
+    /// this.
     template<typename MatrixDerived>
     typename MultiplicationOperatorReturnType<
       DelassusOperatorBase,
@@ -215,22 +235,181 @@ namespace pinocchio
       return ReturnType(derived(), x.derived());
     }
 
-    getDampingReturnType getDamping() const
+    /// \brief Update the numerical damping of the Delassus from a vector.
+    template<typename VectorLike>
+    void updateDamping(const Eigen::MatrixBase<VectorLike> & damping)
     {
-      return derived().getDamping();
+      derived().updateDampingImpl(damping.derived());
     }
 
+    /// \brief Update the numerical damping of the Delassus from a scalar.
+    void updateDamping(const Scalar damping)
+    {
+      updateDamping(VectorXs::Constant(size(), damping));
+    }
+
+    /// \brief Update numerical damping by copying an input block diagonal matrix.
+    template<int OtherOptions, std::size_t OtherAlignment>
+    void updateDamping(
+      const BlockDiagonalMatrixTpl<Scalar, OtherOptions, OtherAlignment> &
+        block_diagonal_damping_matrix)
+    {
+      derived().updateDampingImpl(block_diagonal_damping_matrix);
+    }
+
+    /// \brief Update numerical damping by moving an input block diagonal matrix.
+    template<int OtherOptions, std::size_t OtherAlignment>
+    void updateDamping(
+      BlockDiagonalMatrixTpl<Scalar, OtherOptions, OtherAlignment> && block_diagonal_damping_matrix)
+    {
+      derived().updateDampingImpl(std::move(block_diagonal_damping_matrix));
+    }
+
+    /// \brief Update the physical compliance of the Delassus from a vector.
+    template<typename VectorLike>
+    void updateCompliance(const Eigen::MatrixBase<VectorLike> & compliance)
+    {
+      derived().updateComplianceImpl(compliance.derived());
+    }
+
+    /// \brief Update the physical compliance of the Delassus from a scalar.
+    void updateCompliance(const Scalar compliance)
+    {
+      updateCompliance(VectorXs::Constant(size(), compliance));
+    }
+
+    /// \brief Update the decomposition, following for instance, a call to updateDamping or
+    /// updateCompliance As a result isDirty() returns false after this call.
+    void updateDecomposition()
+    {
+      derived().updateDecompositionImpl();
+      PINOCCHIO_THROW_IF(
+        isDirty(), std::logic_error, "updateDecomposition() should make isDirty false.");
+    }
+
+    /// \returns true if the Delassus is not valid, for instance, after a call to updateDamping or
+    /// updateCompliance
+    bool isDirty() const
+    {
+      return derived().isDirtyImpl();
+    }
+
+    /// \brief Fills input matrix with the dense representation of the Delassus.
+    ///
+    /// \param[in] res The matrix to fill with the dense representation of the Delassus.
+    /// \param[in] enforce_symmetry If true, the output matrix is symmetrized (default false).
+    /// \param[in] with_damping If true, the numerical damping is taken into account (default true).
+    template<typename MatrixType>
+    void matrix(
+      const Eigen::MatrixBase<MatrixType> & res,
+      bool enforce_symmetry = false,
+      bool with_damping = true) const
+    {
+      derived().matrixImpl(res.derived(), enforce_symmetry, with_damping);
+    }
+
+    /// \brief Returns the dense representation of the Delassus.
+    ///
+    /// \param[in] enforce_symmetry If true, the output matrix is symmetrized (default false).
+    /// \param[in] with_damping If true, the numerical damping is taken into account (default true).
+    MatrixXs matrix(bool enforce_symmetry = false, bool with_damping = true) const
+    {
+      MatrixXs res(size(), size());
+      matrix(res, enforce_symmetry, with_damping);
+      return res;
+    }
+
+    /// \brief Fills input matrix with the dense representation of the Delassus.
+    /// The numerical damping is NOT taken into account here.
+    ///
+    /// \param[in] res The matrix to fill with the dense representation of the Delassus.
+    /// \param[in] enforce_symmetry If true, the output matrix is symmetrized (default false).
+    template<typename MatrixType>
+    void
+    undampedMatrix(const Eigen::MatrixBase<MatrixType> & res, bool enforce_symmetry = false) const
+    {
+      matrix(res, enforce_symmetry, false /*no damping*/);
+    }
+
+    /// \brief Returns the dense representation of the Delassus.
+    /// The numerical damping is NOT taken into account here.
+    ///
+    /// \param[in] enforce_symmetry If true, the output matrix is symmetrized (default false).
+    MatrixXs undampedMatrix(bool enforce_symmetry = false) const
+    {
+      MatrixXs res(this->size(), this->size());
+      matrix(res, enforce_symmetry, false /*no damping*/);
+      return res;
+    }
+
+    /// \brief solveInPlace operation returning the results of the inverse of the Delassus operator
+    /// times the input matrix mat
+    ///
+    /// \param[in,out] mat Input/output argument containing the right hand side and the result of
+    /// the operation
+    ///
+    /// \warning The parameter is only marked 'const' to make the C++ compiler accept a temporary
+    /// expression here. This function will const_cast it, so constness isn't honored here.
+    /// This method will throw if updateDecomposition() or compute(true, true) has not been called.
+    template<typename MatrixLike>
+    void solveInPlace(const Eigen::MatrixBase<MatrixLike> & mat) const
+    {
+      PINOCCHIO_THROW_IF(
+        isDirty(), std::logic_error,
+        "The DelassusOperator has dirty quantities. Please call updateDecomposition() first.");
+      derived().solveInPlaceImpl(mat.const_cast_derived());
+    }
+
+    /// \brief Same as \ref solveInPlace but returns the result.
+    template<typename MatrixLike>
+    typename PINOCCHIO_EIGEN_PLAIN_TYPE(MatrixLike)
+      solve(const Eigen::MatrixBase<MatrixLike> & mat) const
+    {
+      typename PINOCCHIO_EIGEN_PLAIN_TYPE(MatrixLike) res(mat);
+      solveInPlace(res);
+      return res;
+    }
+
+    /// \brief Same as \ref solveInPlace but takes the result as an output argument.
+    template<typename MatrixDerivedIn, typename MatrixDerivedOut>
+    void solve(
+      const Eigen::MatrixBase<MatrixDerivedIn> & x,
+      const Eigen::MatrixBase<MatrixDerivedOut> & res) const
+    {
+      res.const_cast_derived() = solve(x.derived());
+    }
+
+    /// \brief Returns the numerical damping of the Delassus.
+    getDampingReturnType getDamping() const
+    {
+      return derived().getDampingImpl();
+    }
+
+    /// \brief Returns the physical compliance of the Delassus.
+    getComplianceReturnType getCompliance() const
+    {
+      return derived().getComplianceImpl();
+    }
+
+    /// \brief Returns the number of size (rows/cols) of the Delassus.
+    /// The Delassus operator represents a size() x size() linear operator.
     Eigen::Index size() const
     {
-      return derived().size();
+      return derived().sizeImpl();
     }
+
+    /// \brief Returns the number of rows of the Delassus. Identical to size().
     Eigen::Index rows() const
     {
-      return derived().rows();
+      assert(derived().rowsImpl() == size());
+      return derived().rowsImpl();
     }
+
+    /// \brief Returns the number of cols of the Delassus. Identical to size().
     Eigen::Index cols() const
     {
-      return derived().cols();
+      assert(derived().colsImpl() == size());
+      return derived().colsImpl();
     }
 
   }; // struct DelassusOperatorBase

--- a/include/pinocchio/src/algorithm/delassus-operator-cholesky-expression.hxx
+++ b/include/pinocchio/src/algorithm/delassus-operator-cholesky-expression.hxx
@@ -96,13 +96,6 @@ namespace pinocchio
     using Base::getDamping;
     using Base::size;
 
-    /// \brief Cast this class to its unsafe version.
-    Unsafe<Self> unsafeImpl()
-    {
-      return Unsafe<Self>(*this);
-    }
-    friend struct Unsafe<Self>;
-
     /// \brief Default constructor from a cholesky decomposition.
     explicit DelassusOperatorCholeskyExpressionTpl(ConstraintCholeskyDecomposition & self)
     : Base()
@@ -149,6 +142,12 @@ namespace pinocchio
     // -------------------------------
     // IMPLEMENTATIONS OF BASE METHODS
     // -------------------------------
+
+    Unsafe<Self> unsafeImpl()
+    {
+      return Unsafe<Self>(*this);
+    }
+    friend struct Unsafe<Self>;
 
     template<typename MatrixIn, typename MatrixOut>
     void applyOnTheRightImpl(

--- a/include/pinocchio/src/algorithm/delassus-operator-cholesky-expression.hxx
+++ b/include/pinocchio/src/algorithm/delassus-operator-cholesky-expression.hxx
@@ -29,7 +29,7 @@ namespace pinocchio
     typedef typename ConstraintCholeskyDecomposition::DampingType DampingType;
     typedef const DampingType & getDampingReturnType;
 
-    typedef typename ContactCholeskyDecomposition::EigenStorageVector EigenStorageVector;
+    typedef typename ConstraintCholeskyDecomposition::EigenStorageVector EigenStorageVector;
     typedef const typename EigenStorageVector::ConstMapType getComplianceReturnType;
   };
 

--- a/include/pinocchio/src/algorithm/delassus-operator-cholesky-expression.hxx
+++ b/include/pinocchio/src/algorithm/delassus-operator-cholesky-expression.hxx
@@ -37,11 +37,11 @@ namespace pinocchio
   /// Allows direct access to protected members for expert users.
   template<typename _ConstraintCholeskyDecomposition>
   struct Unsafe<DelassusOperatorCholeskyExpressionTpl<_ConstraintCholeskyDecomposition>>
-  : Unsafe<DelassusOperatorBase<DelassusOperatorCholeskyExpressionTpl<_ConstraintCholeskyDecomposition>>>
+  : Unsafe<
+      DelassusOperatorBase<DelassusOperatorCholeskyExpressionTpl<_ConstraintCholeskyDecomposition>>>
   {
     typedef DelassusOperatorCholeskyExpressionTpl<_ConstraintCholeskyDecomposition> SafeSelf;
     typedef Unsafe<DelassusOperatorBase<SafeSelf>> Base;
-    friend Base; // to allow Base to call protected stuff
     typedef typename traits<SafeSelf>::DampingType DampingType;
 
     using Base::self;
@@ -51,7 +51,6 @@ namespace pinocchio
     {
     }
 
-  protected:
     void makeDirtyImpl()
     {
       self.self.updateSumComplianceDamping();
@@ -77,7 +76,6 @@ namespace pinocchio
     typedef typename ConstraintCholeskyDecomposition::RowMatrix RowMatrix;
     typedef DelassusOperatorCholeskyExpressionTpl<_ConstraintCholeskyDecomposition> Self;
     typedef DelassusOperatorBase<Self> Base;
-    friend Base; // to allow Base to call protected stuff
     typedef typename ConstraintCholeskyDecomposition::EigenStorageVector EigenStorageVector;
     typedef typename ConstraintCholeskyDecomposition::DampingType DampingType;
     static constexpr int Options = ConstraintCholeskyDecomposition::Options;
@@ -138,7 +136,6 @@ namespace pinocchio
       return self.sizeInBytes();
     }
 
-  protected:
     // -------------------------------
     // IMPLEMENTATIONS OF BASE METHODS
     // -------------------------------

--- a/include/pinocchio/src/algorithm/delassus-operator-cholesky-expression.hxx
+++ b/include/pinocchio/src/algorithm/delassus-operator-cholesky-expression.hxx
@@ -22,45 +22,50 @@ namespace pinocchio
   {
     static constexpr int RowsAtCompileTime = Eigen::Dynamic;
     typedef typename ConstraintCholeskyDecomposition::Scalar Scalar;
-    typedef typename ConstraintCholeskyDecomposition::Matrix Matrix;
-    typedef typename ConstraintCholeskyDecomposition::Vector Vector;
+    typedef typename ConstraintCholeskyDecomposition::Matrix MatrixXs;
+    typedef MatrixXs Matrix;
+    typedef typename ConstraintCholeskyDecomposition::Vector VectorXs;
 
-    typedef typename ConstraintCholeskyDecomposition::EigenStorageVector EigenStorageVector;
-    typedef typename ConstraintCholeskyDecomposition::BlockDiagonalMatrix BlockDiagonalMatrix;
-    typedef const BlockDiagonalMatrix & getDampingReturnType;
+    typedef typename ConstraintCholeskyDecomposition::DampingType DampingType;
+    typedef const DampingType & getDampingReturnType;
+
+    typedef typename ContactCholeskyDecomposition::EigenStorageVector EigenStorageVector;
+    typedef const typename EigenStorageVector::ConstMapType getComplianceReturnType;
   };
 
   /// \brief Unsafe version of DelassusOperatorCholeskyExpressionTpl.
   /// Allows direct access to protected members for expert users.
   template<typename _ConstraintCholeskyDecomposition>
   struct Unsafe<DelassusOperatorCholeskyExpressionTpl<_ConstraintCholeskyDecomposition>>
+  : Unsafe<DelassusOperatorBase<DelassusOperatorCholeskyExpressionTpl<_ConstraintCholeskyDecomposition>>>
   {
     typedef DelassusOperatorCholeskyExpressionTpl<_ConstraintCholeskyDecomposition> SafeSelf;
-    typedef typename SafeSelf::BlockDiagonalMatrix BlockDiagonalMatrix;
+    typedef Unsafe<DelassusOperatorBase<SafeSelf>> Base;
+    friend Base; // to allow Base to call protected stuff
+    typedef typename traits<SafeSelf>::DampingType DampingType;
+
+    using Base::self;
 
     explicit Unsafe(SafeSelf & self)
-    : self(self)
+    : Base(self)
     {
     }
 
-    /// \brief Signal the delassus that updateDecomposition() should be called.
-    /// This is typically called after damping has been directly modified via damping().
-    void makeDirty()
+  protected:
+    void makeDirtyImpl()
     {
       self.self.updateSumComplianceDamping();
     }
 
-    /// \brief Direct access to the block diagonal damping.
-    BlockDiagonalMatrix & damping()
+    DampingType & dampingImpl()
     {
       return self.self.m_damping;
     }
-
-  protected:
-    SafeSelf & self;
   };
 
   // TODO(jcarpent): change const_cast usage.
+  /// \brief Operator for a delassus' cholesky expression representation.
+  /// \copydoc DelassusOperatorBase.
   template<typename _ConstraintCholeskyDecomposition>
   struct DelassusOperatorCholeskyExpressionTpl
   : DelassusOperatorBase<DelassusOperatorCholeskyExpressionTpl<_ConstraintCholeskyDecomposition>>
@@ -72,10 +77,13 @@ namespace pinocchio
     typedef typename ConstraintCholeskyDecomposition::RowMatrix RowMatrix;
     typedef DelassusOperatorCholeskyExpressionTpl<_ConstraintCholeskyDecomposition> Self;
     typedef DelassusOperatorBase<Self> Base;
+    friend Base; // to allow Base to call protected stuff
     typedef typename ConstraintCholeskyDecomposition::EigenStorageVector EigenStorageVector;
-    typedef typename ConstraintCholeskyDecomposition::BlockDiagonalMatrix BlockDiagonalMatrix;
+    typedef typename ConstraintCholeskyDecomposition::DampingType DampingType;
     static constexpr int Options = ConstraintCholeskyDecomposition::Options;
     typedef DelassusOperatorDenseTpl<Scalar, Options> DelassusOperatorDense;
+    typedef typename traits<Self>::getDampingReturnType getDampingReturnType;
+    typedef typename traits<Self>::getComplianceReturnType getComplianceReturnType;
 
     typedef
       typename SizeDepType<Eigen::Dynamic>::template BlockReturn<RowMatrix>::Type RowMatrixBlockXpr;
@@ -85,8 +93,11 @@ namespace pinocchio
     static constexpr int RowsAtCompileTime =
       traits<DelassusOperatorCholeskyExpressionTpl>::RowsAtCompileTime;
 
+    using Base::getDamping;
+    using Base::size;
+
     /// \brief Cast this class to its unsafe version.
-    Unsafe<Self> unsafe()
+    Unsafe<Self> unsafeImpl()
     {
       return Unsafe<Self>(*this);
     }
@@ -99,9 +110,48 @@ namespace pinocchio
     {
     }
 
-    /// \brief Evaluates the product Delassus * x and stores it in res.
+    /// \brief Returns the Constraint Cholesky decomposition associated to this
+    /// DelassusOperatorCholeskyExpression.
+    const ConstraintCholeskyDecomposition & cholesky() const
+    {
+      return self;
+    }
+
+    /// \brief Returns the Constraint Cholesky decomposition associated to this
+    /// DelassusOperatorCholeskyExpression.
+    ConstraintCholeskyDecomposition & cholesky()
+    {
+      return self;
+    }
+
+    /// \brief Returns the inverse of the damped delassus matrix.
+    Matrix inverse() const
+    {
+      return self.getOperationalSpaceInertiaMatrix();
+    }
+
+    ///
+    /// \brief Returns the corresponding dense delassus operator.
+    ///
+    DelassusOperatorDense dense(bool enforce_symmetry = false) const
+    {
+      return DelassusOperatorDense(*this, enforce_symmetry);
+    }
+
+    /// \brief Returns the current memory footprint of this object in bytes.
+    /// \details Sums up the sizes of all internal data members.
+    std::size_t sizeInBytes() const
+    {
+      return self.sizeInBytes();
+    }
+
+  protected:
+    // -------------------------------
+    // IMPLEMENTATIONS OF BASE METHODS
+    // -------------------------------
+
     template<typename MatrixIn, typename MatrixOut>
-    void applyOnTheRight(
+    void applyOnTheRightImpl(
       const Eigen::MatrixBase<MatrixIn> & x,
       const Eigen::MatrixBase<MatrixOut> & res,
       bool with_damping = true) const
@@ -141,27 +191,18 @@ namespace pinocchio
       // }
     }
 
-    ///
-    /// \brief Update the decomposition after a call to updateDamping or updateCompliance.
-    ///
-    /// \remarks isDirty() allows to retrieve the current status of the decomposition.
-    ///
-    void updateDecomposition()
+    void updateDecompositionImpl()
     {
       self.computeDelassusCholeskyDecomposition();
     }
 
-    /// \brief Returns true if updateDecomposition() needs to be called in order to call
-    /// solveInPlace.
-    bool isDirty() const
+    bool isDirtyImpl() const
     {
       return self.isDirty();
     }
 
-    /// \brief solveInPlace operation returning the resultsof the inverse of the Delassus operator
-    /// times the input x.
     template<typename MatrixDerived>
-    void solveInPlace(const Eigen::MatrixBase<MatrixDerived> & x) const
+    void solveInPlaceImpl(const Eigen::MatrixBase<MatrixDerived> & x) const
     {
       PINOCCHIO_CHECK_ARGUMENT_SIZE(x.rows(), self.constraintDim());
 
@@ -184,54 +225,8 @@ namespace pinocchio
       U1.adjoint().solveInPlace(x);
     }
 
-    /// \brief Same as solveInPlace but stores the result in res.
-    template<typename MatrixDerivedIn, typename MatrixDerivedOut>
-    void solve(
-      const Eigen::MatrixBase<MatrixDerivedIn> & x,
-      const Eigen::MatrixBase<MatrixDerivedOut> & res) const
-    {
-      res.const_cast_derived() = x;
-      solveInPlace(res.const_cast_derived());
-    }
-
-    template<typename MatrixDerived>
-    typename PINOCCHIO_EIGEN_PLAIN_TYPE(MatrixDerived)
-      solve(const Eigen::MatrixBase<MatrixDerived> & x) const
-    {
-      typedef typename PINOCCHIO_EIGEN_PLAIN_TYPE(MatrixDerived) ReturnType;
-      ReturnType res(self.constraintDim(), x.cols());
-      solve(x.derived(), res);
-      return res;
-    }
-
-    /// \brief Returns the Constraint Cholesky decomposition associated to this
-    /// DelassusOperatorCholeskyExpression.
-    const ConstraintCholeskyDecomposition & cholesky() const
-    {
-      return self;
-    }
-
-    /// \brief Returns the Constraint Cholesky decomposition associated to this
-    /// DelassusOperatorCholeskyExpression.
-    ConstraintCholeskyDecomposition & cholesky()
-    {
-      return self;
-    }
-
-    /// \brief Returns the matrix resulting from the decomposition.
-    Matrix matrix(bool enforce_symmetry = false, bool with_damping = true) const
-    {
-      Matrix res = self.getInverseOperationalSpaceInertiaMatrix(enforce_symmetry);
-      if (!with_damping)
-      {
-        getDamping().subTo(res);
-      }
-      return res;
-    }
-
-    /// \brief Fill the input matrix with the matrix resulting from the decomposition.
     template<typename MatrixType>
-    void matrix(
+    void matrixImpl(
       const Eigen::MatrixBase<MatrixType> & mat,
       bool enforce_symmetry = false,
       bool with_damping = true) const
@@ -243,144 +238,55 @@ namespace pinocchio
       }
     }
 
-    /// \brief Returns the matrix resulting from the decomposition.
-    /// The numerical damping is NOT taken into account here.
-    Matrix undampedMatrix(bool enforce_symmetry = false) const
-    {
-      Matrix res = matrix(enforce_symmetry, false /*no damping*/);
-      return res;
-    }
-
-    /// \brief Fill the input matrix with the matrix resulting from the decomposition
-    /// The numerical damping is NOT taken into account here.
-    template<typename MatrixType>
-    void
-    undampedMatrix(const Eigen::MatrixBase<MatrixType> & mat, bool enforce_symmetry = false) const
-    {
-      matrix(mat, enforce_symmetry, false /*no damping*/);
-    }
-
-    ///
-    /// \brief Returns the current compliance vector.
-    ///
-    const typename EigenStorageVector::ConstMapType getCompliance() const
+    getComplianceReturnType getComplianceImpl() const
     {
       return self.getCompliance();
     }
 
-    ///
-    /// \brief Returns the current damping as a block diagonal matrix.
-    ///
-    const BlockDiagonalMatrix & getDamping() const
+    getDampingReturnType getDampingImpl() const
     {
       return self.getDamping();
     }
 
-    Matrix inverse() const
-    {
-      return self.getOperationalSpaceInertiaMatrix();
-    }
-
-    ///
-    /// \brief Returns the corresponding dense delassus operator.
-    ///
-    DelassusOperatorDense dense(bool enforce_symmetry = false) const
-    {
-      return DelassusOperatorDense(*this, enforce_symmetry);
-    }
-
-    ///
-    /// \brief Add a compliance term to the diagonal of the Delassus matrix. The compliance terms
-    /// should be all positives.
-    ///
-    /// \param[in] compliances Vector of compliances related to the constraints.
-    ///
     template<typename VectorLike>
-    void updateCompliance(const Eigen::MatrixBase<VectorLike> & compliances)
+    void updateComplianceImpl(const Eigen::MatrixBase<VectorLike> & compliances)
     {
       const_cast<ConstraintCholeskyDecomposition &>(self).updateCompliance(compliances);
     }
 
-    ///
-    /// \brief Add a compliance term to the diagonal of the Delassus matrix. The compliance term
-    /// should be positive.
-    ///
-    /// \param[in] compliance Compliance of the constraints.
-    ///
-    void updateCompliance(const Scalar & compliance)
-    {
-      const_cast<ConstraintCholeskyDecomposition &>(self).updateCompliance(compliance);
-    }
-
-    ///
-    /// \brief Add a damping term to the diagonal of the Delassus matrix. The damping terms should
-    /// be all positives.
-    ///
-    /// \param[in] mus Vector of positive regularization factor allowing to enforce the definite
-    /// positiveness of the matrix.
-    ///
     template<typename VectorLike>
-    void updateDamping(const Eigen::MatrixBase<VectorLike> & mus)
+    void updateDampingImpl(const Eigen::MatrixBase<VectorLike> & mus)
     {
       const_cast<ConstraintCholeskyDecomposition &>(self).updateDamping(mus);
     }
 
-    ///
-    /// \brief Add a damping term to the diagonal of the Delassus matrix. The damping term should be
-    /// positive.
-    ///
-    /// \param[in] mu Regularization factor allowing to enforce the definite positiveness of the
-    /// matrix.
-    ///
-    void updateDamping(const Scalar & mu)
-    {
-      const_cast<ConstraintCholeskyDecomposition &>(self).updateDamping(mu);
-    }
-
-    ///
-    /// \brief Update the damping from a block diagonal matrix (copy overload).
-    ///
     template<int OtherOptions, std::size_t OtherAlignment>
-    void updateDamping(
+    void updateDampingImpl(
       const BlockDiagonalMatrixTpl<Scalar, OtherOptions, OtherAlignment> & block_damping)
     {
       const_cast<ConstraintCholeskyDecomposition &>(self).updateDamping(block_damping);
     }
 
-    ///
-    /// \brief Update the damping from a block diagonal matrix (move overload).
-    ///
     template<int OtherOptions, std::size_t OtherAlignment>
     void
-    updateDamping(BlockDiagonalMatrixTpl<Scalar, OtherOptions, OtherAlignment> && block_damping)
+    updateDampingImpl(BlockDiagonalMatrixTpl<Scalar, OtherOptions, OtherAlignment> && block_damping)
     {
       const_cast<ConstraintCholeskyDecomposition &>(self).updateDamping(std::move(block_damping));
     }
 
-    /// \brief Returns the number of rows/cols of the Delassus.
-    /// The delassus represents a size() x size() linear operator.
-    Eigen::Index size() const
+    Eigen::Index sizeImpl() const
     {
       return self.constraintDim();
     }
 
-    /// \brief Returns the number of rows of the Delassus.
-    Eigen::Index rows() const
+    Eigen::Index rowsImpl() const
     {
       return size();
     }
 
-    /// \brief Returns the number of cols of the Delassus.
-    Eigen::Index cols() const
+    Eigen::Index colsImpl() const
     {
       return size();
-    }
-
-    /// \brief Returns the current memory footprint of this object in bytes.
-    /// \details Sums up the sizes of all internal data members.
-    std::size_t sizeInBytes() const
-    {
-      return self.sizeInBytes();
     }
 
   protected:

--- a/include/pinocchio/src/algorithm/delassus-operator-dense.hxx
+++ b/include/pinocchio/src/algorithm/delassus-operator-dense.hxx
@@ -104,6 +104,28 @@ namespace pinocchio
     {
     }
 
+    DelassusOperatorDenseTpl(const DelassusOperatorDenseTpl & other)
+    : DelassusOperatorDenseTpl()
+    {
+      *this = other;
+    }
+
+    DelassusOperatorDenseTpl & operator=(const DelassusOperatorDenseTpl & other)
+    {
+      if (this != &other)
+      {
+        Base::operator=(other);
+        m_delassus_matrix_storage = other.m_delassus_matrix_storage;
+        m_cholesky_decomposition_data_storage = other.m_cholesky_decomposition_data_storage;
+        m_cholesky_decomposition.~CholeskyDecomposition();
+        new (&m_cholesky_decomposition) CholeskyDecomposition(m_cholesky_decomposition_data);
+        m_cholesky_decomposition_dirty = other.m_cholesky_decomposition_dirty;
+        m_damping = other.m_damping;
+        m_compliance_storage = other.m_compliance_storage;
+      }
+      return *this;
+    }
+
     /// \brief Constructor from a given matrix.
     /// \note The constructor does not compute the cholesky decomposition of the delassus.
     template<typename MatrixDerived>

--- a/include/pinocchio/src/algorithm/delassus-operator-dense.hxx
+++ b/include/pinocchio/src/algorithm/delassus-operator-dense.hxx
@@ -47,7 +47,6 @@ namespace pinocchio
   {
     typedef DelassusOperatorDenseTpl<_Scalar, _Options, CholeskyDecompositionTpl> SafeSelf;
     typedef Unsafe<DelassusOperatorBase<SafeSelf>> Base;
-    friend Base; // to allow Base to call protected stuff
     typedef typename traits<SafeSelf>::DampingType DampingType;
 
     using Base::self;
@@ -57,7 +56,6 @@ namespace pinocchio
     {
     }
 
-  protected:
     void makeDirtyImpl()
     {
       self.m_cholesky_decomposition_dirty = true;
@@ -96,7 +94,6 @@ namespace pinocchio
     typedef typename traits<Self>::DampingType DampingType;
     typedef CholeskyDecompositionTpl<Eigen::Ref<MatrixXs>> CholeskyDecomposition;
     typedef DelassusOperatorBase<Self> Base;
-    friend Base; // to allow Base to call protected stuff
 
     using Base::isDirty;
     using Base::size;
@@ -290,7 +287,6 @@ namespace pinocchio
       return res;
     }
 
-  protected:
     // -------------------------------
     // IMPLEMENTATIONS OF BASE METHODS
     // -------------------------------
@@ -444,6 +440,7 @@ namespace pinocchio
       }
     }
 
+  protected:
     /// \brief Storage for the delassus matrix.
     MatrixStorage m_delassus_matrix_storage;
     MatrixStorageRefMapType m_delassus_matrix = m_delassus_matrix_storage.map();

--- a/include/pinocchio/src/algorithm/delassus-operator-dense.hxx
+++ b/include/pinocchio/src/algorithm/delassus-operator-dense.hxx
@@ -102,13 +102,6 @@ namespace pinocchio
     using Base::size;
     using Base::solveInPlace;
 
-    /// \brief Cast this class to its unsafe version.
-    Unsafe<Self> unsafeImpl()
-    {
-      return Unsafe<Self>(*this);
-    }
-    friend struct Unsafe<Self>;
-
     /// \brief Default constructor.
     DelassusOperatorDenseTpl()
     : Base()
@@ -301,6 +294,12 @@ namespace pinocchio
     // -------------------------------
     // IMPLEMENTATIONS OF BASE METHODS
     // -------------------------------
+
+    Unsafe<Self> unsafeImpl()
+    {
+      return Unsafe<Self>(*this);
+    }
+    friend struct Unsafe<Self>;
 
     template<typename MatrixIn, typename MatrixOut>
     void applyOnTheRightImpl(

--- a/include/pinocchio/src/algorithm/delassus-operator-dense.hxx
+++ b/include/pinocchio/src/algorithm/delassus-operator-dense.hxx
@@ -24,48 +24,54 @@ namespace pinocchio
     static constexpr int Options = _Options;
     static constexpr int RowsAtCompileTime = Eigen::Dynamic;
 
-    typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, Options> Matrix;
-    typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1, Options> Vector;
+    typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, Options> MatrixXs;
+    typedef MatrixXs Matrix; // for eigen lazy evaluation
+    typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1, Options> VectorXs;
 
     typedef BlockDiagonalMatrixTpl<Scalar, Options> BlockDiagonalMatrix;
+    typedef BlockDiagonalMatrix DampingType;
+    typedef const DampingType & getDampingReturnType;
 
-    typedef const BlockDiagonalMatrix & getDampingReturnType;
+    typedef EigenStorageTpl<VectorXs> VectorStorage;
+    typedef const typename VectorStorage::ConstMapType getComplianceReturnType;
   };
 
-  /// \brief Unsafe version of DelassusOperatorDenseTpl.
-  /// Allows to access protected members.
-  /// Meant to be used by expert users.
+  /// \brief \copydoc Unsafe<DelassusOperatorBase>>
   template<
     typename _Scalar,
     int _Options,
     template<typename, auto...> class CholeskyDecompositionTpl>
   struct Unsafe<DelassusOperatorDenseTpl<_Scalar, _Options, CholeskyDecompositionTpl>>
+  : Unsafe<
+      DelassusOperatorBase<DelassusOperatorDenseTpl<_Scalar, _Options, CholeskyDecompositionTpl>>>
   {
     typedef DelassusOperatorDenseTpl<_Scalar, _Options, CholeskyDecompositionTpl> SafeSelf;
-    typedef typename SafeSelf::BlockDiagonalMatrix BlockDiagonalMatrix;
+    typedef Unsafe<DelassusOperatorBase<SafeSelf>> Base;
+    friend Base; // to allow Base to call protected stuff
+    typedef typename traits<SafeSelf>::DampingType DampingType;
+
+    using Base::self;
 
     explicit Unsafe(SafeSelf & self)
-    : self(self)
+    : Base(self)
     {
     }
 
-    /// \brief Signal the delassus that updateDecomposition() should be called.
-    void makeDirty()
+  protected:
+    void makeDirtyImpl()
     {
       self.m_cholesky_decomposition_dirty = true;
     }
 
     /// \brief Getter to the block diagonal damping.
-    BlockDiagonalMatrix & damping()
+    DampingType & dampingImpl()
     {
       return self.m_damping;
     }
-
-  protected:
-    SafeSelf & self;
   };
 
   /// \brief Operator for a delassus' dense representation.
+  /// \copydoc DelassusOperatorBase.
   template<
     typename _Scalar,
     int _Options,
@@ -79,18 +85,25 @@ namespace pinocchio
     static constexpr int Options = _Options;
     static constexpr int RowsAtCompileTime = traits<DelassusOperatorDenseTpl>::RowsAtCompileTime;
 
-    typedef typename traits<Self>::Matrix Matrix;
-    typedef typename traits<Self>::Vector Vector;
-    typedef EigenStorageTpl<Matrix> MatrixStorage;
-    typedef EigenStorageTpl<Vector> VectorStorage;
+    typedef typename traits<Self>::MatrixXs MatrixXs;
+    typedef typename traits<Self>::VectorXs VectorXs;
+    typedef typename traits<Self>::getDampingReturnType getDampingReturnType;
+    typedef typename traits<Self>::getComplianceReturnType getComplianceReturnType;
+    typedef EigenStorageTpl<MatrixXs> MatrixStorage;
+    typedef EigenStorageTpl<VectorXs> VectorStorage;
     typedef typename MatrixStorage::RefMapType MatrixStorageRefMapType;
     typedef typename VectorStorage::RefMapType VectorStorageRefMapType;
-    typedef typename traits<Self>::BlockDiagonalMatrix BlockDiagonalMatrix;
-    typedef CholeskyDecompositionTpl<Eigen::Ref<Matrix>> CholeskyDecomposition;
+    typedef typename traits<Self>::DampingType DampingType;
+    typedef CholeskyDecompositionTpl<Eigen::Ref<MatrixXs>> CholeskyDecomposition;
     typedef DelassusOperatorBase<Self> Base;
+    friend Base; // to allow Base to call protected stuff
+
+    using Base::isDirty;
+    using Base::size;
+    using Base::solveInPlace;
 
     /// \brief Cast this class to its unsafe version.
-    Unsafe<Self> unsafe()
+    Unsafe<Self> unsafeImpl()
     {
       return Unsafe<Self>(*this);
     }
@@ -104,12 +117,14 @@ namespace pinocchio
     {
     }
 
+    /// \brief Copy constructor.
     DelassusOperatorDenseTpl(const DelassusOperatorDenseTpl & other)
     : DelassusOperatorDenseTpl()
     {
       *this = other;
     }
 
+    /// \brief Copy assignment operator.
     DelassusOperatorDenseTpl & operator=(const DelassusOperatorDenseTpl & other)
     {
       if (this != &other)
@@ -182,7 +197,7 @@ namespace pinocchio
       m_cholesky_decomposition_data.setZero();
 
       // resize/reset damping and compliance
-      m_damping = BlockDiagonalMatrix::Zero(mat.rows());
+      m_damping = DampingType::Zero(mat.rows());
       m_compliance_storage.resize(mat.rows());
       m_compliance.setZero();
 
@@ -274,9 +289,21 @@ namespace pinocchio
       return !(*this == other);
     }
 
-    /// \brief Evaluates the product delassus * x and stores it in res.
+    /// \brief Returns the inverse of the damped delassus matrix.
+    MatrixXs inverse() const
+    {
+      MatrixXs res = MatrixXs::Identity(size(), size());
+      solveInPlace(res);
+      return res;
+    }
+
+  protected:
+    // -------------------------------
+    // IMPLEMENTATIONS OF BASE METHODS
+    // -------------------------------
+
     template<typename MatrixIn, typename MatrixOut>
-    void applyOnTheRight(
+    void applyOnTheRightImpl(
       const Eigen::MatrixBase<MatrixIn> & x,
       const Eigen::MatrixBase<MatrixOut> & res_,
       bool with_damping = true) const
@@ -291,38 +318,22 @@ namespace pinocchio
       }
     }
 
-    /// \brief Update physical compliance from a vector.
     template<typename VectorLike>
-    void updateCompliance(const Eigen::MatrixBase<VectorLike> & compliance_vector)
+    void updateComplianceImpl(const Eigen::MatrixBase<VectorLike> & compliance_vector)
     {
       m_compliance = compliance_vector;
       m_cholesky_decomposition_dirty = true;
     }
 
-    /// \brief Update physical compliance from a scalar.
-    void updateCompliance(const Scalar & compliance)
-    {
-      updateCompliance(Vector::Constant(size(), compliance));
-    }
-
-    /// \brief Update numerical damping from a vector.
     template<typename VectorLike>
-    void updateDamping(const Eigen::MatrixBase<VectorLike> & damping_vector)
+    void updateDampingImpl(const Eigen::MatrixBase<VectorLike> & damping_vector)
     {
       m_damping = damping_vector.asDiagonal();
       m_cholesky_decomposition_dirty = true;
     }
 
-    /// \brief Update numerical damping from a scalar.
-    void updateDamping(const Scalar & mu)
-    {
-      m_damping = std::move(BlockDiagonalMatrix::ScalarIdentity(size(), mu));
-      m_cholesky_decomposition_dirty = true;
-    }
-
-    /// \brief Update numerical damping by copying an input block diagonal matrix.
     template<int OtherOptions, std::size_t OtherAlignment>
-    void updateDamping(
+    void updateDampingImpl(
       const BlockDiagonalMatrixTpl<Scalar, OtherOptions, OtherAlignment> &
         block_diagonal_damping_matrix)
     {
@@ -333,9 +344,8 @@ namespace pinocchio
       m_cholesky_decomposition_dirty = true;
     }
 
-    /// \brief Update numerical damping by moving an input block diagonal matrix.
     template<int OtherOptions, std::size_t OtherAlignment>
-    void updateDamping(
+    void updateDampingImpl(
       BlockDiagonalMatrixTpl<Scalar, OtherOptions, OtherAlignment> && block_diagonal_damping_matrix)
     {
       if (&block_diagonal_damping_matrix == &m_damping)
@@ -345,8 +355,7 @@ namespace pinocchio
       m_cholesky_decomposition_dirty = true;
     }
 
-    /// \brief Updates the cholesky decomposition of the delassus.
-    void updateDecomposition()
+    void updateDecompositionImpl()
     {
       if (m_cholesky_decomposition_dirty)
       {
@@ -358,16 +367,13 @@ namespace pinocchio
       }
     }
 
-    /// \brief Returns true if updateDecomposition() needs to be called in order to call
-    /// solveInPlace.
-    bool isDirty() const
+    bool isDirtyImpl() const
     {
       return m_cholesky_decomposition_dirty;
     }
 
-    /// \brief Fills input matrix with the dense representation of the Delassus.
     template<typename MatrixType>
-    void matrix(
+    void matrixImpl(
       const Eigen::MatrixBase<MatrixType> & mat,
       bool enforce_symmetry = false,
       bool with_damping = true) const
@@ -385,36 +391,8 @@ namespace pinocchio
       }
     }
 
-    /// \brief Returns the dense representation of the Delassus.
-    Matrix matrix(bool enforce_symmetry = false, bool with_damping = true) const
-    {
-      Matrix res(rows(), cols());
-      matrix(res, enforce_symmetry, with_damping);
-      return res;
-    }
-
-    /// \brief Fills input matrix with the dense representation of the Delassus.
-    /// The numerical damping is NOT taken into account here.
-    template<typename MatrixType>
-    void
-    undampedMatrix(const Eigen::MatrixBase<MatrixType> & mat, bool enforce_symmetry = false) const
-    {
-      matrix(mat, enforce_symmetry, false /*no damping*/);
-    }
-
-    /// \brief Returns the dense representation of the Delassus.
-    /// The numerical damping is NOT taken into account here.
-    Matrix undampedMatrix(bool enforce_symmetry = false) const
-    {
-      Matrix res(rows(), cols());
-      undampedMatrix(res, enforce_symmetry);
-      return res;
-    }
-
-    /// \brief solveInPlace operation returning the results of the inverse of the Delassus operator
-    /// times the input matrix mat.
     template<typename MatrixLike>
-    void solveInPlace(const Eigen::MatrixBase<MatrixLike> & mat) const
+    void solveInPlaceImpl(const Eigen::MatrixBase<MatrixLike> & mat) const
     {
       PINOCCHIO_THROW_IF(
         isDirty(), std::logic_error,
@@ -422,66 +400,31 @@ namespace pinocchio
       m_cholesky_decomposition.solveInPlace(mat.const_cast_derived());
     }
 
-    /// \brief Same as \ref solveInPlace but returns the result.
-    template<typename MatrixLike>
-    typename PINOCCHIO_EIGEN_PLAIN_TYPE(MatrixLike)
-      solve(const Eigen::MatrixBase<MatrixLike> & mat) const
-    {
-      typename PINOCCHIO_EIGEN_PLAIN_TYPE(MatrixLike) res(mat);
-      solveInPlace(res);
-      return res;
-    }
-
-    /// \brief Same as \ref solveInPlace but stores the result in res.
-    template<typename MatrixDerivedIn, typename MatrixDerivedOut>
-    void solve(
-      const Eigen::MatrixBase<MatrixDerivedIn> & x,
-      const Eigen::MatrixBase<MatrixDerivedOut> & res) const
-    {
-      res.const_cast_derived() = x;
-      solveInPlace(res.const_cast_derived());
-    }
-
-    /// \brief Returns the inverse of the damped delassus matrix.
-    Matrix inverse() const
-    {
-      Matrix res = Matrix::Identity(size(), size());
-      solveInPlace(res);
-      return res;
-    }
-
-    /// \brief Returns the number of rows/cols of the Delassus.
-    /// The delassus represents a size() x size() linear operator.
-    Eigen::Index size() const
+    Eigen::Index sizeImpl() const
     {
       return m_delassus_matrix.rows();
     }
 
-    /// \brief Returns the number of rows of the Delassus.
-    Eigen::Index rows() const
+    Eigen::Index rowsImpl() const
     {
       return m_delassus_matrix.rows();
     }
 
-    /// \brief Returns the number of cols of the Delassus.
-    Eigen::Index cols() const
+    Eigen::Index colsImpl() const
     {
       return m_delassus_matrix.cols();
     }
 
-    /// \brief Const getter for physical compliance.
-    typename VectorStorage::ConstRefConstMapType & getCompliance() const
+    getComplianceReturnType getComplianceImpl() const
     {
       return m_compliance_storage.const_map();
     }
 
-    /// \brief Const getter for numerical damping.
-    const BlockDiagonalMatrix & getDamping() const
+    getDampingReturnType getDampingImpl() const
     {
       return m_damping;
     }
 
-  protected:
     /// \brief Compute the cholesky decomposition of the matrix contained
     /// in m_cholesky_decomposition_data and stores it in place.
     void computeCholeskyDecomposition()
@@ -518,7 +461,7 @@ namespace pinocchio
     bool m_cholesky_decomposition_dirty;
 
     /// \brief Block diagonal numerical damping.
-    BlockDiagonalMatrix m_damping;
+    DampingType m_damping;
 
     /// \brief Physical compliance.
     VectorStorage m_compliance_storage;

--- a/include/pinocchio/src/algorithm/delassus-operator-preconditioned.hxx
+++ b/include/pinocchio/src/algorithm/delassus-operator-preconditioned.hxx
@@ -26,9 +26,10 @@ namespace pinocchio
 
     typedef DelassusOperatorPreconditionedTpl Self;
     typedef DelassusOperatorBase<Self> Base;
+    friend Base;
 
-    typedef typename traits<Self>::Matrix Matrix;
-    typedef typename traits<Self>::Vector Vector;
+    typedef typename traits<Self>::MatrixXs MatrixXs;
+    typedef typename traits<Self>::VectorXs VectorXs;
     typedef typename traits<Self>::Scalar Scalar;
 
     DelassusOperatorPreconditionedTpl(
@@ -50,44 +51,37 @@ namespace pinocchio
       return m_delassus;
     }
 
+  protected:
+    // implementation of the DelassusOperator concept
+
     template<typename VectorLike>
-    void updateDamping(const Eigen::MatrixBase<VectorLike> & vec)
+    void updateDampingImpl(const Eigen::MatrixBase<VectorLike> & vec)
     {
       // G_bar + mu * Id = P * (G + mu * P^{-2}) * P
       m_preconditioner.scaleSquare(vec, m_tmp_vec);
       ref().updateDamping(m_tmp_vec);
     }
 
-    void updateDamping(const Scalar mu)
-    {
-      this->updateDamping(Vector::Constant(ref().size(), mu));
-    }
-
     template<typename VectorLike>
-    void updateCompliance(const Eigen::MatrixBase<VectorLike> & compliance_vector)
+    void updateComplianceImpl(const Eigen::MatrixBase<VectorLike> & compliance_vector)
     {
       // G_bar + mu * Id = P * (G + mu * P^{-2}) * P
       m_preconditioner.scaleSquare(compliance_vector, m_tmp_vec);
       ref().updateCompliance(m_tmp_vec);
     }
 
-    void updateCompliance(const Scalar mu)
-    {
-      this->updateCompliance(Vector::Constant(ref().size(), mu));
-    }
-
-    bool isDirty() const
+    bool isDirtyImpl() const
     {
       return ref().isDirty();
     }
 
-    void updateDecomposition()
+    void updateDecompositionImpl()
     {
       ref().updateDecomposition();
     }
 
     template<typename MatrixLike>
-    void solveInPlace(const Eigen::MatrixBase<MatrixLike> & mat) const
+    void solveInPlaceImpl(const Eigen::MatrixBase<MatrixLike> & mat) const
     {
       auto & mat_ = mat.const_cast_derived();
       m_preconditioner.scaleInPlace(mat_);
@@ -95,26 +89,8 @@ namespace pinocchio
       m_preconditioner.scaleInPlace(mat_);
     }
 
-    template<typename MatrixLike>
-    typename PINOCCHIO_EIGEN_PLAIN_TYPE(MatrixLike)
-      solve(const Eigen::MatrixBase<MatrixLike> & mat) const
-    {
-      typename PINOCCHIO_EIGEN_PLAIN_TYPE(MatrixLike) res(mat);
-      solveInPlace(res);
-      return res;
-    }
-
-    template<typename MatrixDerivedIn, typename MatrixDerivedOut>
-    void solve(
-      const Eigen::MatrixBase<MatrixDerivedIn> & x,
-      const Eigen::MatrixBase<MatrixDerivedOut> & res) const
-    {
-      res.const_cast_derived() = x;
-      solveInPlace(res.const_cast_derived());
-    }
-
     template<typename MatrixIn, typename MatrixOut>
-    void applyOnTheRight(
+    void applyOnTheRightImpl(
       const Eigen::MatrixBase<MatrixIn> & x,
       const Eigen::MatrixBase<MatrixOut> & res,
       bool with_damping = true) const
@@ -125,41 +101,46 @@ namespace pinocchio
       m_preconditioner.unscale(m_tmp_vec, res_);
     }
 
-    Eigen::Index size() const
+    Eigen::Index sizeImpl() const
     {
       return ref().size();
     }
-    Eigen::Index rows() const
+    Eigen::Index rowsImpl() const
     {
       return ref().rows();
     }
-    Eigen::Index cols() const
+    Eigen::Index colsImpl() const
     {
       return ref().cols();
     }
 
-    Matrix matrix(bool enforce_symmetry = false) const
+    template<typename MatrixType>
+    void matrixImpl(
+      const Eigen::MatrixBase<MatrixType> & res,
+      bool enforce_symmetry = false,
+      bool with_damping = true) const
     {
-      return m_preconditioner.getDiagonal().asDiagonal() * m_delassus.matrix(enforce_symmetry)
-             * m_preconditioner.getDiagonal().asDiagonal();
+      MatrixType & res_ = res.const_cast_derived();
+      m_delassus.matrix(res_, enforce_symmetry, with_damping);
+      res_.noalias() = m_preconditioner.getDiagonal().asDiagonal() * res_;
+      res_.noalias() = res_ * m_preconditioner.getDiagonal().asDiagonal();
     }
 
-    Vector getDamping() const
+    VectorXs getDampingImpl() const
     {
       m_preconditioner.unscaleSquare(ref().getDamping(), m_tmp_vec);
       return m_tmp_vec;
     }
 
-    Vector getCompliance() const
+    VectorXs getComplianceImpl() const
     {
       m_preconditioner.unscaleSquare(ref().getCompliance(), m_tmp_vec);
       return m_tmp_vec;
     }
 
-  protected:
     DelassusOperator & m_delassus;
     const PreconditionerType & m_preconditioner;
-    Vector m_tmp_vec;
+    VectorXs m_tmp_vec;
 
   }; // struct DelassusOperatorPreconditioned
 

--- a/include/pinocchio/src/algorithm/delassus-operator-preconditioned.hxx
+++ b/include/pinocchio/src/algorithm/delassus-operator-preconditioned.hxx
@@ -26,7 +26,6 @@ namespace pinocchio
 
     typedef DelassusOperatorPreconditionedTpl Self;
     typedef DelassusOperatorBase<Self> Base;
-    friend Base;
 
     typedef typename traits<Self>::MatrixXs MatrixXs;
     typedef typename traits<Self>::VectorXs VectorXs;
@@ -51,8 +50,9 @@ namespace pinocchio
       return m_delassus;
     }
 
-  protected:
-    // implementation of the DelassusOperator concept
+    // -------------------------------
+    // IMPLEMENTATIONS OF BASE METHODS
+    // -------------------------------
 
     template<typename VectorLike>
     void updateDampingImpl(const Eigen::MatrixBase<VectorLike> & vec)

--- a/include/pinocchio/src/algorithm/delassus-operator-rigid-body.hxx
+++ b/include/pinocchio/src/algorithm/delassus-operator-rigid-body.hxx
@@ -92,7 +92,6 @@ namespace pinocchio
       _StorageHolder>
       SafeSelf;
     typedef Unsafe<DelassusOperatorBase<SafeSelf>> Base;
-    friend Base; // to allow Base to call protected stuff
     typedef typename traits<SafeSelf>::DampingType DampingType;
 
     using Base::self;
@@ -102,7 +101,6 @@ namespace pinocchio
     {
     }
 
-  protected:
     void makeDirtyImpl()
     {
       self.updateSumComplianceDamping();
@@ -134,7 +132,6 @@ namespace pinocchio
 
     typedef DelassusOperatorRigidBodySystemsTpl Self;
     typedef DelassusOperatorBase<Self> Base;
-    friend Base; // to allow Base to call protected stuff
 
     typedef typename traits<Self>::Scalar Scalar;
     static constexpr int Options = traits<Self>::Options;
@@ -292,7 +289,6 @@ namespace pinocchio
       return helper::get_ref(m_constraint_datas_ref);
     }
 
-  protected:
     // -------------------------------
     // IMPLEMENTATIONS OF BASE METHODS
     // -------------------------------

--- a/include/pinocchio/src/algorithm/delassus-operator-rigid-body.hxx
+++ b/include/pinocchio/src/algorithm/delassus-operator-rigid-body.hxx
@@ -193,6 +193,33 @@ namespace pinocchio
       rebuild(model_ref, data_ref, constraint_models_ref, constraint_datas_ref);
     }
 
+    DelassusOperatorRigidBodySystemsTpl(const DelassusOperatorRigidBodySystemsTpl & other)
+    : DelassusOperatorRigidBodySystemsTpl(
+        other.m_model_ref,
+        other.m_data_ref,
+        other.m_constraint_models_ref,
+        other.m_constraint_datas_ref,
+        other.m_min_damping_value)
+    {
+      m_internal_data = other.m_internal_data;
+      m_solve_in_place_dirty = other.m_solve_in_place_dirty;
+      m_damping = other.m_damping;
+      m_compliance_storage = other.m_compliance_storage;
+      m_sum_compliance_damping = other.m_sum_compliance_damping;
+      m_sum_compliance_damping_inverse = other.m_sum_compliance_damping_inverse;
+    }
+
+    DelassusOperatorRigidBodySystemsTpl &
+    operator=(const DelassusOperatorRigidBodySystemsTpl & other)
+    {
+      if (this != &other)
+      {
+        this->~DelassusOperatorRigidBodySystemsTpl();
+        new (this) DelassusOperatorRigidBodySystemsTpl(other);
+      }
+      return *this;
+    }
+
     /// \brief Update the constraint model and data vectors, and resize the internal quantities.
     ///
     /// \param[in] constraint_models_ref Vector of constraint models
@@ -450,6 +477,32 @@ namespace pinocchio
       , f(std::size_t(model.njoints))
       , of_augmented(std::size_t(model.njoints))
       {
+      }
+
+      InternalData(const InternalData & other)
+      : a(other.a)
+      , oa_augmented(other.oa_augmented)
+      , u_storage(other.u_storage)
+      , u(u_storage.map())
+      , ddq_storage(other.ddq_storage)
+      , ddq(ddq_storage.map())
+      , f(other.f)
+      , of_augmented(other.of_augmented)
+      {
+      }
+
+      InternalData & operator=(const InternalData & other)
+      {
+        if (this != &other)
+        {
+          a = other.a;
+          oa_augmented = other.oa_augmented;
+          u_storage = other.u_storage;
+          ddq_storage = other.ddq_storage;
+          f = other.f;
+          of_augmented = other.of_augmented;
+        }
+        return *this;
       }
 
       /// \brief Rebuild from a given model.

--- a/include/pinocchio/src/algorithm/delassus-operator-rigid-body.hxx
+++ b/include/pinocchio/src/algorithm/delassus-operator-rigid-body.hxx
@@ -33,11 +33,11 @@ namespace pinocchio
     static constexpr int Options = _Options;
     static constexpr int RowsAtCompileTime = Eigen::Dynamic;
 
-    typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1, Options> Vector;
-    typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, Options> DenseMatrix;
-    typedef DenseMatrix Matrix;
+    typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1, Options> VectorXs;
+    typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, Options> MatrixXs;
+    typedef MatrixXs Matrix;
 
-    typedef EigenStorageTpl<Vector> EigenStorageVector;
+    typedef EigenStorageTpl<VectorXs> EigenStorageVector;
     typedef BlockDiagonalMatrixTpl<Scalar, Options> BlockDiagonalMatrix;
 
     typedef ModelTpl<Scalar, Options, JointCollectionTpl> Model;
@@ -57,7 +57,9 @@ namespace pinocchio
     typedef std::vector<ConstraintModel> ConstraintModelVector;
     typedef std::vector<ConstraintData> ConstraintDataVector;
 
-    typedef const BlockDiagonalMatrix & getDampingReturnType;
+    typedef BlockDiagonalMatrix DampingType;
+    typedef const DampingType & getDampingReturnType;
+    typedef typename EigenStorageVector::ConstMapType getComplianceReturnType;
   };
 
   /// \brief Unsafe version of DelassusOperatorRigidBodySystemsTpl.
@@ -75,6 +77,12 @@ namespace pinocchio
     _JointCollectionTpl,
     _ConstraintModel,
     _StorageHolder>>
+  : Unsafe<DelassusOperatorBase<DelassusOperatorRigidBodySystemsTpl<
+      _Scalar,
+      _Options,
+      _JointCollectionTpl,
+      _ConstraintModel,
+      _StorageHolder>>>
   {
     typedef DelassusOperatorRigidBodySystemsTpl<
       _Scalar,
@@ -83,32 +91,32 @@ namespace pinocchio
       _ConstraintModel,
       _StorageHolder>
       SafeSelf;
-    typedef typename SafeSelf::BlockDiagonalMatrix BlockDiagonalMatrix;
+    typedef Unsafe<DelassusOperatorBase<SafeSelf>> Base;
+    friend Base; // to allow Base to call protected stuff
+    typedef typename traits<SafeSelf>::DampingType DampingType;
+
+    using Base::self;
 
     explicit Unsafe(SafeSelf & self)
-    : self(self)
+    : Base(self)
     {
     }
 
-    /// \brief Signal the delassus that updateDecomposition() should be called.
-    /// This is typically called after damping or compliance has been updated
-    /// so updateSumComplianceDamping is called internally.
-    void makeDirty()
+  protected:
+    void makeDirtyImpl()
     {
       self.updateSumComplianceDamping();
       self.m_solve_in_place_dirty = true;
     }
 
-    /// \brief Getter to the block diagonal damping.
-    BlockDiagonalMatrix & damping()
+    DampingType & dampingImpl()
     {
       return self.m_damping;
     }
-
-  protected:
-    SafeSelf & self;
   };
 
+  /// \brief Operator for a delassus' low-complexity representation.
+  /// \copydoc DelassusOperatorBase.
   template<
     typename _Scalar,
     int _Options,
@@ -126,14 +134,17 @@ namespace pinocchio
 
     typedef DelassusOperatorRigidBodySystemsTpl Self;
     typedef DelassusOperatorBase<Self> Base;
+    friend Base; // to allow Base to call protected stuff
 
     typedef typename traits<Self>::Scalar Scalar;
     static constexpr int Options = traits<Self>::Options;
 
-    typedef typename traits<Self>::Vector Vector;
-    typedef typename traits<Self>::DenseMatrix DenseMatrix;
+    typedef typename traits<Self>::VectorXs VectorXs;
+    typedef typename traits<Self>::MatrixXs MatrixXs;
     typedef typename traits<Self>::EigenStorageVector EigenStorageVector;
     typedef typename traits<Self>::BlockDiagonalMatrix BlockDiagonalMatrix;
+    typedef typename traits<Self>::getDampingReturnType getDampingReturnType;
+    typedef typename traits<Self>::getComplianceReturnType getComplianceReturnType;
 
     typedef typename traits<Self>::Model Model;
     typedef StorageHolder<const Model> ModelHolder;
@@ -141,7 +152,6 @@ namespace pinocchio
     typedef StorageHolder<Data> DataHolder;
 
     typedef typename Data::Force Force;
-    typedef typename Data::VectorXs VectorXs;
     typedef std::vector<Force> ForceVector;
 
     typedef typename traits<Self>::ConstraintModel ConstraintModel;
@@ -154,8 +164,10 @@ namespace pinocchio
     typedef typename traits<Self>::ConstraintDataVector ConstraintDataVector;
     typedef StorageHolder<const ConstraintDataVector> ConstraintDataVectorHolder;
 
+    using Base::size;
+
     /// \brief Cast this class to its unsafe version.
-    Unsafe<Self> unsafe()
+    Unsafe<Self> unsafeImpl()
     {
       return Unsafe<Self>(*this);
     }
@@ -231,7 +243,6 @@ namespace pinocchio
       const ConstraintModelVectorHolder & constraint_models_ref,
       const ConstraintDataVectorHolder & constraint_datas_ref);
 
-    ///
     /// \brief Update the intermediate computations before calling solveInPlace or operator*
     ///
     /// \param[in] apply_on_the_right If true, this will update the quantities involved in the
@@ -249,145 +260,6 @@ namespace pinocchio
       compute_or_update_decomposition(apply_on_the_right, solve_in_place);
     }
 
-    /// \brief Stores the product delassus * x in res.
-    template<typename MatrixIn, typename MatrixOut>
-    void applyOnTheRight(
-      const Eigen::MatrixBase<MatrixIn> & x,
-      const Eigen::MatrixBase<MatrixOut> & res,
-      bool with_damping = true) const;
-
-    /// \brief Update the numerical damping of the delassus from a vector.
-    template<typename VectorLike>
-    void updateDamping(const Eigen::MatrixBase<VectorLike> & damping_vector)
-    {
-      m_damping = damping_vector.asDiagonal();
-      updateSumComplianceDamping();
-    }
-
-    /// \brief Update the numerical damping of the delassus from a scalar.
-    void updateDamping(const Scalar & mu)
-    {
-      updateDamping(Vector::Constant(size(), mu));
-    }
-
-    /// \brief Update numerical damping by copying an input block diagonal matrix.
-    template<int OtherOptions, std::size_t OtherAlignment>
-    void updateDamping(
-      const BlockDiagonalMatrixTpl<Scalar, OtherOptions, OtherAlignment> &
-        block_diagonal_damping_matrix)
-    {
-      if (&block_diagonal_damping_matrix == &m_damping)
-        return;
-
-      m_damping = block_diagonal_damping_matrix;
-      updateSumComplianceDamping();
-    }
-
-    /// \brief Update numerical damping by moving an input block diagonal matrix.
-    template<int OtherOptions, std::size_t OtherAlignment>
-    void updateDamping(
-      BlockDiagonalMatrixTpl<Scalar, OtherOptions, OtherAlignment> && block_diagonal_damping_matrix)
-    {
-      if (&block_diagonal_damping_matrix == &m_damping)
-        return;
-
-      m_damping = std::move(block_diagonal_damping_matrix);
-      updateSumComplianceDamping();
-    }
-
-    /// \brief Update the physical compliance of the delassus from a vector.
-    template<typename VectorLike>
-    void updateCompliance(const Eigen::MatrixBase<VectorLike> & compliance_vector)
-    {
-      m_compliance = compliance_vector;
-      updateSumComplianceDamping();
-    }
-
-    /// \brief Update the physical compliance of the delassus from a scalar.
-    void updateCompliance(const Scalar & compliance_value)
-    {
-      updateCompliance(Vector::Constant(size(), compliance_value));
-    }
-
-    ///
-    /// \brief Update the decomposition after a call to updateDamping or updateCompliance.
-    ///
-    /// \remarks isDirty() allows to retrieve the current status of the decomposition.
-    ///
-    void updateDecomposition()
-    {
-      compute(false, true);
-    }
-
-    /// \brief Returns true if updateDecomposition() needs to be called in order to call
-    /// solveInPlace.
-    bool isDirty() const
-    {
-      return m_solve_in_place_dirty;
-    }
-
-    /// \brief Fills input matrix with the dense representation of the Delassus.
-    template<typename MatrixType>
-    void matrix(
-      const Eigen::MatrixBase<MatrixType> & res,
-      bool enforce_symmetry = false,
-      bool with_damping = true) const
-    {
-      MatrixType & res_ = res.const_cast_derived();
-      typedef Eigen::Map<VectorXs> MapVectorXs;
-      MapVectorXs x = MapVectorXs(PINOCCHIO_EIGEN_MAP_ALLOCA(Scalar, this->size(), 1));
-
-      for (Eigen::Index i = 0; i < this->size(); ++i)
-      {
-        x = VectorXs::Unit(this->size(), i);
-        this->applyOnTheRight(x, res_.col(i), with_damping);
-      }
-      if (enforce_symmetry)
-      {
-        res_ = 0.5 * (res_ + res_.transpose());
-      }
-    }
-
-    /// \brief Returns the dense representation of the Delassus.
-    DenseMatrix matrix(bool enforce_symmetry = false, bool with_damping = true) const
-    {
-      DenseMatrix res(this->size(), this->size());
-      matrix(res, enforce_symmetry, with_damping);
-      return res;
-    }
-
-    /// \brief Fills input matrix with the dense representation of the Delassus.
-    /// The numerical damping is NOT taken into account here.
-    template<typename MatrixType>
-    void
-    undampedMatrix(const Eigen::MatrixBase<MatrixType> & res, bool enforce_symmetry = false) const
-    {
-      matrix(res, enforce_symmetry, false /*no damping*/);
-    }
-
-    /// \brief Returns the dense representation of the Delassus.
-    /// The numerical damping is NOT taken into account here.
-    DenseMatrix undampedMatrix(bool enforce_symmetry = false) const
-    {
-      DenseMatrix res(this->size(), this->size());
-      matrix(res, enforce_symmetry, false /*no damping*/);
-      return res;
-    }
-
-    /// \brief solveInPlace operation returning the results of the inverse of the Delassus operator
-    /// times the input matrix mat
-    ///
-    /// \param[in,out] mat Input/output argument containing the right hand side and the result of
-    /// the operation
-    ///
-    /// \warning The parameter is only marked 'const' to make the C++ compiler accept a temporary
-    /// expression here. This function will const_cast it, so constness isn't honored here.
-    ///
-    /// \remarks Even if the method is marked 'const', it will update the internal decomposition if
-    /// the Delassus operator is dirty after an update of the damping or compliance values.
-    template<typename MatrixLike>
-    void solveInPlace(const Eigen::MatrixBase<MatrixLike> & mat) const;
-
     /// \brief Returns the current memory footprint of this object in bytes.
     /// \details Sums up the sizes of all internal data members.
     std::size_t sizeInBytes() const
@@ -395,25 +267,6 @@ namespace pinocchio
       return m_damping.sizeInBytes() + m_compliance_storage.sizeInBytes()
              + m_sum_compliance_damping.sizeInBytes()
              + m_sum_compliance_damping_inverse.sizeInBytes() + m_internal_data.sizeInBytes();
-    }
-
-    /// \brief Returns the number of rows/cols of the Delassus.
-    /// The delassus represents a size() x size() linear operator.
-    Eigen::Index size() const
-    {
-      return m_size;
-    }
-
-    /// \brief Returns the number of rows of the Delassus.
-    Eigen::Index rows() const
-    {
-      return m_size;
-    }
-
-    /// \brief Returns the number of cols of the Delassus.
-    Eigen::Index cols() const
-    {
-      return m_size;
     }
 
     /// \brief Const getter for model.
@@ -446,18 +299,116 @@ namespace pinocchio
       return helper::get_ref(m_constraint_datas_ref);
     }
 
-    /// \brief Const getter for the numerical damping.
-    const BlockDiagonalMatrix & getDamping() const
+  protected:
+    // -------------------------------
+    // IMPLEMENTATIONS OF BASE METHODS
+    // -------------------------------
+
+    template<typename MatrixIn, typename MatrixOut>
+    void applyOnTheRightImpl(
+      const Eigen::MatrixBase<MatrixIn> & x,
+      const Eigen::MatrixBase<MatrixOut> & res,
+      bool with_damping = true) const;
+
+    template<typename VectorLike>
+    void updateDampingImpl(const Eigen::MatrixBase<VectorLike> & damping_vector)
+    {
+      m_damping = damping_vector.asDiagonal();
+      updateSumComplianceDamping();
+    }
+
+    template<int OtherOptions, std::size_t OtherAlignment>
+    void updateDampingImpl(
+      const BlockDiagonalMatrixTpl<Scalar, OtherOptions, OtherAlignment> &
+        block_diagonal_damping_matrix)
+    {
+      if (&block_diagonal_damping_matrix == &m_damping)
+        return;
+
+      m_damping = block_diagonal_damping_matrix;
+      updateSumComplianceDamping();
+    }
+
+    template<int OtherOptions, std::size_t OtherAlignment>
+    void updateDampingImpl(
+      BlockDiagonalMatrixTpl<Scalar, OtherOptions, OtherAlignment> && block_diagonal_damping_matrix)
+    {
+      if (&block_diagonal_damping_matrix == &m_damping)
+        return;
+
+      m_damping = std::move(block_diagonal_damping_matrix);
+      updateSumComplianceDamping();
+    }
+
+    template<typename VectorLike>
+    void updateComplianceImpl(const Eigen::MatrixBase<VectorLike> & compliance_vector)
+    {
+      m_compliance = compliance_vector;
+      updateSumComplianceDamping();
+    }
+
+    void updateDecompositionImpl()
+    {
+      compute_or_update_decomposition(false, true);
+    }
+
+    bool isDirtyImpl() const
+    {
+      return m_solve_in_place_dirty;
+    }
+
+    template<typename MatrixType>
+    void matrixImpl(
+      const Eigen::MatrixBase<MatrixType> & res,
+      bool enforce_symmetry = false,
+      bool with_damping = true) const
+    {
+      MatrixType & res_ = res.const_cast_derived();
+      typedef Eigen::Map<VectorXs> MapVectorXs;
+      MapVectorXs x = MapVectorXs(PINOCCHIO_EIGEN_MAP_ALLOCA(Scalar, this->size(), 1));
+
+      for (Eigen::Index i = 0; i < this->size(); ++i)
+      {
+        x = VectorXs::Unit(this->size(), i);
+        this->applyOnTheRight(x, res_.col(i), with_damping);
+      }
+      if (enforce_symmetry)
+      {
+        res_ = 0.5 * (res_ + res_.transpose());
+      }
+    }
+
+    template<typename MatrixLike>
+    void solveInPlaceImpl(const Eigen::MatrixBase<MatrixLike> & mat) const;
+
+    Eigen::Index sizeImpl() const
+    {
+      return m_size;
+    }
+
+    /// \brief Returns the number of rows of the Delassus.
+    Eigen::Index rowsImpl() const
+    {
+      return m_size;
+    }
+
+    /// \brief Returns the number of cols of the Delassus.
+    Eigen::Index colsImpl() const
+    {
+      return m_size;
+    }
+
+    getDampingReturnType getDampingImpl() const
     {
       return m_damping;
     }
 
-    /// \brief Const getter for the physical compliance.
-    typename EigenStorageVector::ConstRefConstMapType getCompliance() const
+    getComplianceReturnType getComplianceImpl() const
     {
       return m_compliance_storage.const_map();
     }
 
+  public:
     /// \brief Internal data needed for the various passes of the delassus operator.
     struct InternalData
     {
@@ -818,7 +769,7 @@ namespace pinocchio
     JointCollectionTpl,
     ConstraintModel,
     StorageHolder>::
-    applyOnTheRight(
+    applyOnTheRightImpl(
       const Eigen::MatrixBase<MatrixIn> & rhs,
       const Eigen::MatrixBase<MatrixOut> & res_,
       bool with_damping) const
@@ -946,7 +897,7 @@ namespace pinocchio
     Options,
     JointCollectionTpl,
     ConstraintModel,
-    StorageHolder>::solveInPlace(const Eigen::MatrixBase<MatrixLike> & mat_) const
+    StorageHolder>::solveInPlaceImpl(const Eigen::MatrixBase<MatrixLike> & mat_) const
   {
     MatrixLike & mat = mat_.const_cast_derived();
     PINOCCHIO_CHECK_ARGUMENT_SIZE(

--- a/include/pinocchio/src/algorithm/delassus-operator-rigid-body.hxx
+++ b/include/pinocchio/src/algorithm/delassus-operator-rigid-body.hxx
@@ -166,13 +166,6 @@ namespace pinocchio
 
     using Base::size;
 
-    /// \brief Cast this class to its unsafe version.
-    Unsafe<Self> unsafeImpl()
-    {
-      return Unsafe<Self>(*this);
-    }
-    friend struct Unsafe<Self>;
-
     /// \brief Default constructor from model, data, constraint_models and constraint_datas.
     DelassusOperatorRigidBodySystemsTpl(
       const ModelHolder & model_ref,
@@ -303,6 +296,12 @@ namespace pinocchio
     // -------------------------------
     // IMPLEMENTATIONS OF BASE METHODS
     // -------------------------------
+
+    Unsafe<Self> unsafeImpl()
+    {
+      return Unsafe<Self>(*this);
+    }
+    friend struct Unsafe<Self>;
 
     template<typename MatrixIn, typename MatrixOut>
     void applyOnTheRightImpl(

--- a/include/pinocchio/src/algorithm/delassus-operator-sparse.hxx
+++ b/include/pinocchio/src/algorithm/delassus-operator-sparse.hxx
@@ -143,7 +143,6 @@ namespace pinocchio
     typedef typename traits<Self>::MatrixXs MatrixXs;
     typedef SparseCholeskyDecomposition CholeskyDecomposition;
     typedef DelassusOperatorBase<Self> Base;
-    friend Base; // to allow Base to call protected stuff
 
     typedef typename traits<Self>::getDampingReturnType getDampingReturnType;
     typedef typename traits<Self>::getComplianceReturnType getComplianceReturnType;
@@ -187,7 +186,6 @@ namespace pinocchio
       return res;
     }
 
-  protected:
     // -------------------------------
     // IMPLEMENTATIONS OF BASE METHODS
     // -------------------------------
@@ -289,6 +287,7 @@ namespace pinocchio
       return m_damping;
     }
 
+  protected:
     SparseMatrix m_delassus_matrix;
     mutable SparseMatrix m_damped_delassus_matrix;
     CholeskyDecomposition m_cholsky_decomposition;

--- a/include/pinocchio/src/algorithm/delassus-operator-sparse.hxx
+++ b/include/pinocchio/src/algorithm/delassus-operator-sparse.hxx
@@ -118,12 +118,16 @@ namespace pinocchio
     static constexpr int Options = _Options;
     static constexpr int RowsAtCompileTime = Eigen::Dynamic;
 
-    typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1, Options> Vector;
-    typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, Options> Matrix;
+    typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1, Options> VectorXs;
+    typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, Options> MatrixXs;
+    typedef MatrixXs Matrix; // for eigen lazy expression
 
-    typedef const Vector & getDampingReturnType;
+    typedef const VectorXs & getDampingReturnType;
+    typedef const VectorXs & getComplianceReturnType;
   };
 
+  /// \brief Operator for a delassus' sparse representation.
+  /// \copydoc DelassusOperatorBase.
   template<typename _Scalar, int _Options, class SparseCholeskyDecomposition>
   struct DelassusOperatorSparseTpl
   : DelassusOperatorBase<DelassusOperatorSparseTpl<_Scalar, _Options, SparseCholeskyDecomposition>>
@@ -135,11 +139,19 @@ namespace pinocchio
     static constexpr int RowsAtCompileTime = traits<Self>::RowsAtCompileTime;
 
     typedef typename traits<Self>::SparseMatrix SparseMatrix;
-    typedef typename traits<Self>::Vector Vector;
-    typedef typename traits<Self>::Matrix Matrix;
+    typedef typename traits<Self>::VectorXs VectorXs;
+    typedef typename traits<Self>::MatrixXs MatrixXs;
     typedef SparseCholeskyDecomposition CholeskyDecomposition;
     typedef DelassusOperatorBase<Self> Base;
+    friend Base; // to allow Base to call protected stuff
 
+    typedef typename traits<Self>::getDampingReturnType getDampingReturnType;
+    typedef typename traits<Self>::getComplianceReturnType getComplianceReturnType;
+
+    using Base::isDirty;
+    using Base::size;
+
+    /// \brief Default constructor from a given sparse matrix.
     template<typename MatrixDerived>
     explicit DelassusOperatorSparseTpl(const Eigen::SparseMatrixBase<MatrixDerived> & mat)
     : Base()
@@ -147,14 +159,41 @@ namespace pinocchio
     , m_damped_delassus_matrix(mat)
     , m_cholsky_decomposition(mat)
     , m_cholesky_decomposition_dirty(true)
-    , m_damping(Vector::Zero(mat.rows()))
-    , m_compliance(Vector::Zero(mat.rows()))
+    , m_damping(VectorXs::Zero(mat.rows()))
+    , m_compliance(VectorXs::Zero(mat.rows()))
     {
       PINOCCHIO_CHECK_ARGUMENT_SIZE(mat.rows(), mat.cols());
     }
 
+    /// \brief Returns the sparse matrix representation of the delassus operator, including the
+    /// compliance and damping.
+    ///
+    /// \param with_damping Whether to include the damping in the returned matrix. Default is true.
+    SparseMatrix sparseMatrix(bool with_damping = true) const
+    {
+      m_damped_delassus_matrix = m_delassus_matrix;
+      m_damped_delassus_matrix += m_compliance.asDiagonal();
+      if (with_damping)
+        m_damped_delassus_matrix += m_damping.asDiagonal();
+      return m_damped_delassus_matrix;
+    }
+
+    /// \brief Returns the sparse inverse of the damped delassus matrix.
+    SparseMatrix inverse() const
+    {
+      SparseMatrix identity_matrix(size(), size());
+      identity_matrix.setIdentity();
+      SparseMatrix res = m_cholsky_decomposition.solve(identity_matrix);
+      return res;
+    }
+
+  protected:
+    // -------------------------------
+    // IMPLEMENTATIONS OF BASE METHODS
+    // -------------------------------
+
     template<typename VectorLike>
-    void updateCompliance(const Eigen::MatrixBase<VectorLike> & compliance_vector)
+    void updateComplianceImpl(const Eigen::MatrixBase<VectorLike> & compliance_vector)
     {
       for (Eigen::Index k = 0; k < size(); ++k)
       {
@@ -164,13 +203,8 @@ namespace pinocchio
       m_cholesky_decomposition_dirty = true;
     }
 
-    void updateCompliance(const Scalar & m_compliance)
-    {
-      updateCompliance(Vector::Constant(size(), m_compliance));
-    }
-
     template<typename VectorLike>
-    void updateDamping(const Eigen::MatrixBase<VectorLike> & damping_vector)
+    void updateDampingImpl(const Eigen::MatrixBase<VectorLike> & damping_vector)
     {
       for (Eigen::Index k = 0; k < size(); ++k)
       {
@@ -180,24 +214,34 @@ namespace pinocchio
       m_cholesky_decomposition_dirty = true;
     }
 
-    void updateDamping(const Scalar & mu)
-    {
-      updateDamping(Vector::Constant(size(), mu));
-    }
-
-    void updateDecomposition()
+    void updateDecompositionImpl()
     {
       m_cholsky_decomposition.factorize(m_damped_delassus_matrix);
       m_cholesky_decomposition_dirty = false;
     }
 
-    bool isDirty() const
+    bool isDirtyImpl() const
     {
       return m_cholesky_decomposition_dirty;
     }
 
+    template<typename MatrixType>
+    void matrixImpl(
+      const Eigen::MatrixBase<MatrixType> & mat,
+      bool enforce_symmetry = false,
+      bool with_damping = true) const
+    {
+      MatrixType & mat_ = mat.const_cast_derived();
+      mat_ = m_delassus_matrix;
+      mat_ += m_compliance.asDiagonal();
+      if (with_damping)
+        mat_ += m_damping.asDiagonal();
+      if (enforce_symmetry)
+        enforceSymmetry(mat_);
+    }
+
     template<typename MatrixLike>
-    void solveInPlace(const Eigen::MatrixBase<MatrixLike> & mat) const
+    void solveInPlaceImpl(const Eigen::MatrixBase<MatrixLike> & mat) const
     {
       PINOCCHIO_THROW_IF(
         isDirty(), std::logic_error,
@@ -206,26 +250,8 @@ namespace pinocchio
         m_cholsky_decomposition, mat.derived(), mat.const_cast_derived());
     }
 
-    template<typename MatrixLike>
-    typename PINOCCHIO_EIGEN_PLAIN_TYPE(MatrixLike)
-      solve(const Eigen::MatrixBase<MatrixLike> & mat) const
-    {
-      typename PINOCCHIO_EIGEN_PLAIN_TYPE(MatrixLike) res(mat);
-      solveInPlace(res);
-      return res;
-    }
-
-    template<typename MatrixDerivedIn, typename MatrixDerivedOut>
-    void solve(
-      const Eigen::MatrixBase<MatrixDerivedIn> & x,
-      const Eigen::MatrixBase<MatrixDerivedOut> & res) const
-    {
-      res.const_cast_derived() = x;
-      m_cholsky_decomposition._solve_impl(x, res.const_cast_derived());
-    }
-
     template<typename MatrixIn, typename MatrixOut>
-    void applyOnTheRight(
+    void applyOnTheRightImpl(
       const Eigen::MatrixBase<MatrixIn> & x,
       const Eigen::MatrixBase<MatrixOut> & res_,
       bool with_damping = true) const
@@ -240,58 +266,35 @@ namespace pinocchio
       }
     }
 
-    Eigen::Index size() const
+    Eigen::Index sizeImpl() const
     {
       return m_delassus_matrix.rows();
     }
-    Eigen::Index rows() const
+    Eigen::Index rowsImpl() const
     {
       return m_delassus_matrix.rows();
     }
-    Eigen::Index cols() const
+    Eigen::Index colsImpl() const
     {
       return m_delassus_matrix.cols();
     }
 
-    SparseMatrix matrix(bool enforce_symmetry = false) const
-    {
-      m_damped_delassus_matrix = m_delassus_matrix;
-      m_damped_delassus_matrix += m_compliance.asDiagonal();
-      m_damped_delassus_matrix += m_damping.asDiagonal();
-      if (enforce_symmetry)
-      {
-        // TODO: enforce symmetry for sparse matrices
-        PINOCCHIO_THROW(
-          std::invalid_argument, "enforceSymmetry not implemented for sparse matrices");
-      }
-      return m_damped_delassus_matrix;
-    }
-
-    const Vector & getCompliance() const
+    getComplianceReturnType getComplianceImpl() const
     {
       return m_compliance;
     }
 
-    const Vector & getDamping() const
+    getDampingReturnType getDampingImpl() const
     {
       return m_damping;
     }
 
-    SparseMatrix inverse() const
-    {
-      SparseMatrix identity_matrix(size(), size());
-      identity_matrix.setIdentity();
-      SparseMatrix res = m_cholsky_decomposition.solve(identity_matrix);
-      return res;
-    }
-
-  protected:
     SparseMatrix m_delassus_matrix;
     mutable SparseMatrix m_damped_delassus_matrix;
     CholeskyDecomposition m_cholsky_decomposition;
     bool m_cholesky_decomposition_dirty;
-    Vector m_damping;
-    Vector m_compliance;
+    VectorXs m_damping;
+    VectorXs m_compliance;
 
   }; // struct DelassusOperatorSparseTpl
 

--- a/unittest/delassus-operator-dense.cpp
+++ b/unittest/delassus-operator-dense.cpp
@@ -193,4 +193,40 @@ BOOST_AUTO_TEST_CASE(delassus_unsafe)
   BOOST_CHECK(delassus.getDamping().diagonal() == damping);
 }
 
+BOOST_AUTO_TEST_CASE(test_copy)
+{
+  const Eigen::Index mat_size = 10;
+  const Eigen::MatrixXd mat_ = Eigen::MatrixXd::Random(mat_size, mat_size);
+  const Eigen::MatrixXd symmetric_mat = mat_.transpose() * mat_;
+  const Eigen::VectorXd compliance = Eigen::VectorXd::LinSpaced(mat_size, 1e-4, 1e-3);
+
+  DelassusOperatorDense delassus(symmetric_mat);
+  delassus.updateCompliance(compliance);
+  const Eigen::MatrixXd expected_matrix = delassus.matrix();
+  const Eigen::VectorXd expected_compliance = delassus.getCompliance();
+
+  // copy constructor: values match
+  DelassusOperatorDense delassus_copy(delassus);
+  BOOST_CHECK(delassus_copy.matrix().isApprox(expected_matrix));
+  BOOST_CHECK(delassus_copy.getCompliance().isApprox(expected_compliance));
+
+  // copy constructor: independence — modifying original does not affect copy
+  const Eigen::MatrixXd new_mat_ = Eigen::MatrixXd::Random(mat_size, mat_size);
+  const Eigen::MatrixXd new_symmetric_mat = new_mat_.transpose() * new_mat_;
+  delassus.rebuild(new_symmetric_mat);
+  delassus.updateCompliance(Eigen::VectorXd::Zero(mat_size));
+  BOOST_CHECK(delassus_copy.matrix().isApprox(expected_matrix));
+  BOOST_CHECK(delassus_copy.getCompliance().isApprox(expected_compliance));
+
+  // copy assignment: values match
+  DelassusOperatorDense delassus_assigned;
+  delassus_assigned = delassus;
+  BOOST_CHECK(delassus_assigned.matrix().isApprox(delassus.matrix()));
+  BOOST_CHECK(delassus_assigned.getCompliance().isApprox(delassus.getCompliance()));
+
+  // copy assignment: independence
+  delassus.updateCompliance(compliance);
+  BOOST_CHECK(!delassus_assigned.getCompliance().isApprox(compliance));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/delassus-operator-rigid-body.cpp
+++ b/unittest/delassus-operator-rigid-body.cpp
@@ -1570,4 +1570,64 @@ BOOST_AUTO_TEST_CASE(general_test_no_constraints)
   }
 }
 
+BOOST_AUTO_TEST_CASE(test_copy)
+{
+  typedef JointFrictionConstraintModelTpl<double> ConstraintModel;
+  typedef DelassusOperatorRigidBodySystemsTpl<
+    double, 0, JointCollectionDefaultTpl, ConstraintModel, std::reference_wrapper>
+    DelassusOperator;
+  typedef typename DelassusOperator::ConstraintModelVector ConstraintModelVector;
+  typedef typename DelassusOperator::ConstraintDataVector ConstraintDataVector;
+
+  Model model;
+  buildModels::manipulator(model);
+  model.lowerDryFrictionLimit.setConstant(-1.0);
+  model.upperDryFrictionLimit.setConstant(1.0);
+  Data data(model);
+
+  ConstraintModelVector constraint_models;
+  ConstraintDataVector constraint_datas;
+  JointFrictionConstraintModel::JointIndexVector active_joints;
+  for (size_t i = 1; i < model.joints.size(); ++i)
+    active_joints.push_back(model.joints[i].id());
+  JointFrictionConstraintModel joints_friction(model, active_joints);
+  constraint_models.push_back(joints_friction);
+  constraint_datas.push_back(joints_friction.createData());
+
+  const Eigen::VectorXd q = neutral(model);
+  computeJointJacobians(model, data, q);
+  data.q_in = q;
+  calc(model, data, constraint_models, constraint_datas);
+
+  const double compliance_value = 1e-2;
+  DelassusOperator delassus(
+    helper::make_ref(model), helper::make_ref(data), helper::make_ref(constraint_models),
+    helper::make_ref(constraint_datas));
+  delassus.updateCompliance(compliance_value);
+  delassus.compute();
+
+  // copy constructor: maps must point to the copy's own storage
+  DelassusOperator delassus_copy(delassus);
+  BOOST_CHECK(access(delassus_copy).m_compliance.data() != access(delassus).m_compliance.data());
+  BOOST_CHECK(access(delassus_copy).m_compliance.isApprox(access(delassus).m_compliance));
+
+  // copy constructor: independence — modify original, copy unchanged
+  const double new_compliance_value = 5e-3;
+  delassus.updateCompliance(new_compliance_value);
+  BOOST_CHECK(access(delassus_copy).m_compliance.isConstant(compliance_value, 0));
+
+  // copy assignment: maps must point to the assigned object's own storage
+  DelassusOperator delassus_assigned(
+    helper::make_ref(model), helper::make_ref(data), helper::make_ref(constraint_models),
+    helper::make_ref(constraint_datas));
+  delassus_assigned = delassus;
+  BOOST_CHECK(
+    access(delassus_assigned).m_compliance.data() != access(delassus).m_compliance.data());
+  BOOST_CHECK(access(delassus_assigned).m_compliance.isApprox(access(delassus).m_compliance));
+
+  // copy assignment: independence — modify original, assigned copy unchanged
+  delassus.updateCompliance(compliance_value);
+  BOOST_CHECK(access(delassus_assigned).m_compliance.isConstant(new_compliance_value, 0));
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Clean delassus API.
The base delassus now clearly defines the API and calls `derived.[name-of-method]Impl()` when needed.

## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the doxygen documentation
- [x] I have added tests that prove my fix or feature works
- [ ] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [ ] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
