### PR TITLE
bindings/utils/dependencies.cpp : fix use of wrong define to tag URDF feature

### DIFF
--- a/bindings/python/utils/dependencies.cpp
+++ b/bindings/python/utils/dependencies.cpp
@@ -12,7 +12,7 @@
   #define WITH_COLLISION false
 #endif
 
-#ifdef PINOCCHIO_WITH_URDF
+#ifdef PINOCCHIO_WITH_URDFDOM
   #define WITH_URDF true
 #else
   #define WITH_URDF false


### PR DESCRIPTION
## Description

`pin.WITH_URDF` always evaluated to `False`.

One consequence is that the unit tests `bindings_geometry_model_urdf.py` were always skipped.

## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the doxygen documentation
- [x] I have added tests that prove my fix or feature works
- [x] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [x] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
